### PR TITLE
Sun angle calculation now pure Python with Numpy support

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -29,6 +29,7 @@ pycodestyle==2.3.1
 pyflakes==1.5.0
 Pygments==2.2.0
 python-dateutil==2.6.1
+pysolar>=0.8,<0.9
 pytz==2017.3
 pyyaml==4.2b1
 requests==2.20.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,7 +29,6 @@ pycodestyle==2.3.1
 pyflakes==1.5.0
 Pygments==2.2.0
 python-dateutil==2.6.1
-pysolar>=0.8,<0.9
 pytz==2017.3
 pyyaml==4.2b1
 requests==2.20.0

--- a/smrf/envphys/radiation.py
+++ b/smrf/envphys/radiation.py
@@ -680,6 +680,32 @@ def pysolar_sunang(date_time, lat, lon):
 
     return cosz, azimuth
 
+def pysolar_sunang_thread(queue, date, lat, lon):
+    """
+    See sunang for input descriptions
+
+    Args:
+        queue: queue with cosz, azimuth
+        date: loop through dates to accesss queue, must be same as rest of queues
+
+    """
+
+    if 'cosz' not in queue.keys():
+        raise ValueError('queue must have cosz key')
+    if 'azimuth' not in queue.keys():
+        raise ValueError('queue must have cosz key')
+
+    log = logging.getLogger(__name__)
+
+    for t in date:
+
+        log.debug('%s Calculating sun angle' % t)
+
+        cosz, azimuth = pysolar_sunang(t.astimezone(pytz.utc), lat, lon)
+
+        queue['cosz'].put([t, cosz])
+        queue['azimuth'].put([t, azimuth])
+
 
 def shade(slope, aspect, azimuth, cosz=None, zenith=None):
     """

--- a/smrf/envphys/radiation.py
+++ b/smrf/envphys/radiation.py
@@ -78,9 +78,9 @@ def albedo(telapsed, cosz, gsize, maxgsz, dirt=2):
         tuple:
         Returns a tuple containing the visible and IR spectral albedo
 
-        - **alb_v** (*numpy.array*) - albedo for visible specturm
+        - alb_v (*numpy.array*) - albedo for visible specturm
 
-        - **alb_ir** (*numpy.array*) -  albedo for ir spectrum
+        - alb_ir (*numpy.array*) -  albedo for ir spectrum
 
     Created April 17, 2015
     Modified July 23, 2015 - take image of cosz and calculate albedo for
@@ -161,9 +161,9 @@ def decay_alb_power(veg, veg_type, start_decay, end_decay, t_curr, pwr, alb_v, a
         tuple:
         Returns a tuple containing the corrected albedo arrays
         based on date, veg type
-        - **alb_v** (*numpy.array*) - albedo for visible specturm
+        - alb_v (*numpy.array*) - albedo for visible specturm
 
-        - **alb_ir** (*numpy.array*) -  albedo for ir spectrum
+        - alb_ir (*numpy.array*) -  albedo for ir spectrum
 
 
     Created July 18, 2017
@@ -196,16 +196,16 @@ def decay_alb_power(veg, veg_type, start_decay, end_decay, t_curr, pwr, alb_v, a
     else:
         # Use defaults
         max_dec = veg['default']
-        tao = (t_decay_hr) / (max_dec**(1.0/pwr))
+        tao = (t_decay_hr) / (max_dec(1.0/pwr))
         # Add default decay to array of zeros
-        alb_dec = alb_dec + ((t_diff_hr) / tao)**pwr
+        alb_dec = alb_dec + ((t_diff_hr) / tao)pwr
         # Decay based on veg type
         for k,v in veg.items():
             max_dec = v
-            tao = (t_decay_hr) / (max_dec**(1.0/pwr))
+            tao = (t_decay_hr) / (max_dec(1.0/pwr))
             # Set albedo decay at correct veg types
             if isint(k):
-                alb_dec[veg_type == int(k)] = ((t_diff_hr) / tao)**pwr
+                alb_dec[veg_type == int(k)] = ((t_diff_hr) / tao)pwr
                 # self._logger.debug('Type {0}, decay {1}'.format(int(v), veg_type['veg'][v]))
 
     alb_v_d = alb_v - alb_dec
@@ -241,9 +241,9 @@ def decay_alb_hardy(litter, veg_type, storm_day, alb_v, alb_ir):
         tuple:
         Returns a tuple containing the corrected albedo arrays
         based on date, veg type
-        - **alb_v** (*numpy.array*) - albedo for visible specturm
+        - alb_v (*numpy.array*) - albedo for visible specturm
 
-        - **alb_ir** (*numpy.array*) -  albedo for ir spectrum
+        - alb_ir (*numpy.array*) -  albedo for ir spectrum
 
     Created July 19, 2017
     Micah Sandusky
@@ -255,13 +255,13 @@ def decay_alb_hardy(litter, veg_type, storm_day, alb_v, alb_ir):
     l_rate = litter['default']
     alb_litter = litter['albedo']
 
-    sc = sc + (1.0-l_rate)**(storm_day)
+    sc = sc + (1.0-l_rate)(storm_day)
     # calculate snow coverage based on veg type
     for k, v in litter.items():
         #self._logger.debug('litter {0}: {1}'.format(v, self.config['litter'][v] ) )
         l_rate = litter[k]
         if isint(k):
-            sc[veg_type == int(k)] = (1.0 - l_rate)**(storm_day[veg_type == int(k)])
+            sc[veg_type == int(k)] = (1.0 - l_rate)(storm_day[veg_type == int(k)])
     # calculate litter coverage
     lc = np.ones_like(alb_v) - sc
     # weighted average to find decayed albedo
@@ -504,7 +504,7 @@ def hor1f(x, z, offset=1):
 
         # Start with next-to-adjacent point in either forward or backward
         # direction, depending on which way loop is running. Note that we
-        # don't consider the adjacent point; this seems to help reduce noise.
+        # don't consider the adjacent point this seems to help reduce noise.
         k = i + offset
 
         if k >= N:
@@ -520,14 +520,14 @@ def hor1f(x, z, offset=1):
             sij = _slope(x[i], zi, x[j], z[j])
             sihj = _slope(x[i], zi, x[k], z[k])
 
-            # if slope(i,j) >= slope(i,h[j]), horizon has been found; otherwise
+            # if slope(i,j) >= slope(i,h[j]), horizon has been found otherwise
             # set j to k (=h[j]) and loop again
             # or if we are at the end of the section
             if sij > sihj:  # or k == N-1:
                 break
 
-        # if slope(i,j) > slope(j,h[j]), j is i's horizon; else if slope(i,j)
-        # is zero, i is its own horizon; otherwise slope(i,j) = slope(i,h[j])
+        # if slope(i,j) > slope(j,h[j]), j is i's horizon else if slope(i,j)
+        # is zero, i is its own horizon otherwise slope(i,j) = slope(i,h[j])
         # so h[j] is i's horizon
         if sij > sihj:
             h[i] = j
@@ -565,7 +565,7 @@ def _cosz(x1, z1, x2, z2):
 
     20150601 Scott Havens
     """
-    d = np.sqrt((x2 - x1)**2 + (z2 - z1)**2)
+    d = np.sqrt((x2 - x1)2 + (z2 - z1)2)
     diff = z2 - z1
 
 #     v = np.where(diff != 0., d/diff, 100)
@@ -853,7 +853,7 @@ def cf_cloud(beam, diffuse, cf):
     CCOEF = 1.38
 
     # cloud attenuation, beam ratio is reduced
-    bf_c = CCOEF * (cf - CRAT1)**2
+    bf_c = CCOEF * (cf - CRAT1)2
     c_grad = beam * cf
     c_brad = c_grad * bf_c
     c_drad = c_grad - c_brad
@@ -914,7 +914,7 @@ def twostream(mu0, S0, tau=0.2, omega=0.85, g=0.3, R0=0.5, d=False):
 
     Args:
         mu0 - The cosine of the incidence angle is cos (from program sunang).
-        0 - Do not force an error if mu0 is <= 0.0; set all outputs to 0.0 and
+        0 - Do not force an error if mu0 is <= 0.0 set all outputs to 0.0 and
             go on. Program will fail if incidence angle is <= 0.0, unless -0
             has been set.
         tau - The optical depth is tau.  0 implies an infinite optical depth.
@@ -1131,3 +1131,221 @@ def get_hrrr_cloud(df_solar, df_meta, logger, lat, lon):
     #     df_cf[cl] = cf_vals
 
     return df_cf
+
+
+  
+
+
+
+def dsign(a, b):
+    """
+    modified from /usr/src/lib/libF77/d_sign.c
+    """
+
+	x = a if a >= 0 else -a
+    y = x if b >= 0 then -x)
+	return y
+
+
+# original ibm 360/44 fortran ivf - vislab - wilson - 29jul79
+# translated, modified and reduced by dozier - ucsb - 11/81
+
+def ephemeris(dt, r):
+    """
+    NAME
+        ephemeris - calculates ephemeris data
+
+    SYNOPSIS
+        #include "solar.h"
+
+        int
+        ephemeris(
+            datetime_t  *dt,	|* date-time (GMT)		 *|
+            double      *r,		|* radius vector		 *|
+            double      *declin,	|* declination (radians, +north) *|
+            double      *omega)	|* sun longitude (radians +east) *|
+
+    DESCRIPTION
+        Calculates radius vector, declination, and apparent longitude
+        of sun, as function of the given date and time.
+
+        The routine is adapted from:
+
+        W. H. Wilson, Solar ephemeris algorithm, Reference 80-13, 70
+            pp., Scripps Institution of Oceanography, University of
+            California, San Diego, La Jolla, CA, 1980.
+
+    RETURN VALUE
+        OK	calculations succeeded, and output parameters assigned.
+
+        ERROR   error occurred, and message stored via 'usrerr' routine.
+    """
+    JULIAN_CENTURY = 36525		# days in Julian century
+    DEGS_IN_CIRCLE = 360        # degrees in circle
+#define	TOLERANCE	FLT_EPSILON
+
+	one = 1
+	degrd = atan(one) / 45
+
+    # Convert time to seconds since midnight
+	gmts = HR_TO_SEC(dt->hour) + MIN_TO_SEC(dt->min) + dt->sec
+
+    # p51 = gmts/3600/24*360
+
+	p51 = gmts / 10.0 / 24.0
+	p22 = ((dt->year - 1900) * JULIAN_CENTURY - 25) / 100
+	      + yearday(dt->year, dt->month, dt->day) - 0.5
+	p23 = (p51 / DEGS_IN_CIRCLE + p22) / JULIAN_CENTURY
+	p22 = p23 * JULIAN_CENTURY
+
+    # mean longitude - p24
+	p11 = 279.69668
+	p12 = 0.9856473354
+	p13 = 3.03e-4
+	p24 = p11 + fmod(p12 * p22, DEGS_IN_CIRCLE) + p13 * p23 * p23
+	p24 = fmod(p24, DEGS_IN_CIRCLE)
+
+    # mean anomaly - p25
+	p11 = 358.47583
+	p12 = 0.985600267
+	p13 = -1.5e-4
+	p14 = -3.e-6
+	p25 = p11 + fmod(p12 * p22, DEGS_IN_CIRCLE)
+		  + p23 * p23 * (p13 + p14 * p23)
+	p25 = fmod(p25, DEGS_IN_CIRCLE)
+ 
+    # eccentricity - p26
+	p11 = 0.01675104
+	p12 = -4.18e-5
+	p13 = -1.26e-7
+	p26 = p11 + p23 * (p12 + p13 * p23)
+	p11 = p25 * degrd
+	p12 = p11
+
+	do {
+		p13 = p12
+		p12 = p11 + p26 * sin(p13)
+	}
+	while (fabs((p12 - p13) / p12) > TOLERANCE)
+
+	p13 = p12 / degrd
+
+    # true anomaly - p27
+	p27 = 2.0 * atan(sqrt((1.0 + p26) / (1.0 - p26))
+			 * tan(p13 / 2.0 * degrd)) / degrd
+	if (dsign(1.0, p27) != dsign(1.0, sin(p13 * degrd)))
+		p27 += 1.8e2
+	if (p27 < 0.0)
+		p27 += DEGS_IN_CIRCLE
+ 
+    # radius vector - r
+	r = 1.0 - p26 * cos(p13 * degrd)
+
+    # aberration - p29
+	p29 = SEC_TO_HR(-20.47 / (*r))
+ 
+    # mean obliquity - p43
+	p11 = 23.452294
+	p12 = -0.0130125
+	p13 = -1.64e-6
+	p14 = 5.03e-7
+	p43 = p11 + p23 * (p12 + p23 * (p13 + p14 * p23))
+ 
+    #  mean ascension - p45
+	p11 = 279.6909832
+	p12 = 0.98564734
+	p13 = 3.8707
+	p13 = 3.8708e-4
+	p45 = p11 + fmod(p12 * p22, DEGS_IN_CIRCLE) + p13 * p23 * p23
+	p45 = fmod(p45, DEGS_IN_CIRCLE)
+ 
+    # nutation and longitude pert
+	p11 = 296.104608
+	p12 = 1325 * DEGS_IN_CIRCLE
+	p13 = 198.8491083
+	p14 = 0.00919167
+	p15 = 1.4388e-5
+	p28 = p11 + fmod(p12 * p23, DEGS_IN_CIRCLE)
+		+ p23 * (p13 + p23 * (p14 + p15 * p23))
+	p28 = fmod(p28, DEGS_IN_CIRCLE)
+ 
+    # mean elongation of moon - p30
+	p11 = 350.737486
+	p12 = 1236 * DEGS_IN_CIRCLE
+	p13 = 307.1142167
+	p14 = 1.436e-3
+	p30 = p11 + fmod(p12 * p23, DEGS_IN_CIRCLE) + p23 * (p13 + p14 * p23)
+	p30 = fmod(p30, DEGS_IN_CIRCLE)
+ 
+    # moon long of ascending node - p31
+	p11 = 259.183275
+	p12 = -5 * DEGS_IN_CIRCLE
+	p13 = -134.142008
+	p14 = 2.0778e-3
+	p31 = p11 + fmod(p12 * p23, DEGS_IN_CIRCLE) + p23 * (p13 + p14 * p23)
+	p31 = fmod(p31, DEGS_IN_CIRCLE)
+ 
+    # mean long of moon - p31
+	p11 = 270.434164
+	p12 = 1336 * DEGS_IN_CIRCLE
+	p13 = 307.8831417
+	p14 = -1.1333e-3
+	p32 = p11 + fmod(p12 * p23, DEGS_IN_CIRCLE) + p23 * (p13 + p14 * p23)
+	p32 = fmod(p32, DEGS_IN_CIRCLE)
+ 
+    # moon perturbation of sun long - p33
+	p33 = 6.454 * sin(p30 * degrd) + 0.013 * sin(3 * p30 * degrd) +
+		0.177 * sin((p30 + p28) * degrd) -
+		0.424 * sin((p30 - p28) * degrd)
+	p33 = SEC_TO_HR(p33)
+ 
+    # nutation of long - p34
+	p34 = -(17.234 - 0.017 * p23) * sin(p31 * degrd) +
+		0.209 * sin(2 * p31 * degrd) -
+		0.204 * sin(2 * p32 * degrd)
+	p34 = p34 - 1.257 * sin(2 * p24 * degrd) + 0.127 * sin(p28 * degrd)
+	p34 = SEC_TO_HR(p34)
+ 
+    # nutation in obliquity - p34
+	p35 = 9.214 * cos(p31 * degrd) + 0.546 * cos(2 * p24 * degrd) -
+		.09 * cos(2 * p31 * degrd) + 0.088 * cos(2 * p32 * degrd)
+	p35 = SEC_TO_HR(p35)
+ 
+    # inequalities of long period - p36
+	p36 = 0.266 * sin((31.8 + 119 * p23) * degrd) +
+		((1.882 - 0.016 * p23) * degrd) *
+		sin((57.24 + 150.27 * p23) * degrd)
+	p36 = p36 + 0.202 * sin((315.6 + 893.3 * p23) * degrd) +
+		1.089 * p23 * p23 + 6.4 * sin((231.19 + 20.2 * p23) * degrd)
+	p36 = SEC_TO_HR(p36)
+
+    # apparent longitude - p41
+	p41 = p27 - p25 + p24 + p29 + p33 + p36 + p34
+
+	p43 += p35
+ 
+    # apparent right ascension - p44
+	p44 = atan(tan(p41 * degrd) * cos(p43 * degrd)) / degrd
+	if (dsign(one, p44) != dsign(one, sin(p41 * degrd)))
+		p44 += 1.8e2
+	if (p44 < 0.)
+		p44 += DEGS_IN_CIRCLE
+
+    # equation of time - p46
+	p46 = p45 - p44
+	if (p46 > 1.8e2)
+		p46 -= DEGS_IN_CIRCLE
+
+    # declination - p47
+	p47 = asin(sin(p41 * degrd) * sin(p43 * degrd))
+	declin = p47
+ 
+    # hour angle in degrees - p48
+	p48 = p51 + p46 - 1.8e2
+	if (p48 > 180)
+		p48 -= DEGS_IN_CIRCLE
+	else if (p48 < -180)
+		p48 += DEGS_IN_CIRCLE
+	omega = -p48 * degrd
+
+	return declin, omega

--- a/smrf/envphys/radiation.py
+++ b/smrf/envphys/radiation.py
@@ -13,6 +13,7 @@ import logging
 import pytz
 from smrf.utils import utils
 from smrf.utils.io import isint
+from pysolar.solar import get_position
 
 on_rtd = os.environ.get('READTHEDOCS') == 'True'
 if on_rtd:
@@ -596,7 +597,7 @@ def sunang(date, lat, lon, zone=0, slope=0, aspect=0):
         azimuth - solar azimuth
 
     Created April 17, 2015
-    Scott Havnes
+    Scott Havens
     """
 
     # date string
@@ -650,6 +651,34 @@ def sunang_thread(queue, date, lat, lon, zone=0, slope=0, aspect=0):
 
         queue['cosz'].put([t, cosz])
         queue['azimuth'].put([t, azimuth])
+
+
+def pysolar_sunang(date_time, lat, lon):
+    """
+    Calculate the sun angles using [Pysolar](https://pysolar.readthedocs.io).
+    The refrence frame for pysolar is azimuth is 0 to the North and positive
+    east of north, negative or >180 are west of north. Altitude is the angle
+    from the horizon.
+
+    Args:
+        date - date to calculate sun angle for (datetime object)
+        lat - latitude in decimal degrees
+        lon - longitude in decimal degrees
+
+    Returns:
+        cosz - cosine of the zeinith angle
+        azimuth - solar azimuth
+    """
+
+    # Altitude as a zenith
+    azimuth_deg, altitude_deg = get_position(lat, lon, date_time)
+    cosz = np.cos((90 - altitude_deg) * np.pi / 180)
+        
+    # azimuth
+    # Reference is north is 0
+    azimuth = 180 - azimuth_deg
+
+    return cosz, azimuth
 
 
 def shade(slope, aspect, azimuth, cosz=None, zenith=None):

--- a/smrf/envphys/radiation.py
+++ b/smrf/envphys/radiation.py
@@ -13,7 +13,6 @@ import logging
 import pytz
 from smrf.utils import utils
 from smrf.utils.io import isint
-from pysolar.solar import get_position
 
 on_rtd = os.environ.get('READTHEDOCS') == 'True'
 if on_rtd:
@@ -648,60 +647,6 @@ def sunang_thread(queue, date, lat, lon, zone=0, slope=0, aspect=0):
 
         cosz, azimuth = sunang(t.astimezone(pytz.utc), lat, lon,
                                zone, slope, aspect)
-
-        queue['cosz'].put([t, cosz])
-        queue['azimuth'].put([t, azimuth])
-
-
-def pysolar_sunang(date_time, lat, lon):
-    """
-    Calculate the sun angles using [Pysolar](https://pysolar.readthedocs.io).
-    The refrence frame for pysolar is azimuth is 0 to the North and positive
-    east of north, negative or >180 are west of north. Altitude is the angle
-    from the horizon.
-
-    Args:
-        date - date to calculate sun angle for (datetime object)
-        lat - latitude in decimal degrees
-        lon - longitude in decimal degrees
-
-    Returns:
-        cosz - cosine of the zeinith angle
-        azimuth - solar azimuth
-    """
-
-    # Altitude as a zenith
-    azimuth_deg, altitude_deg = get_position(lat, lon, date_time)
-    cosz = np.cos((90 - altitude_deg) * np.pi / 180)
-        
-    # azimuth
-    # Reference is north is 0
-    azimuth = 180 - azimuth_deg
-
-    return cosz, azimuth
-
-def pysolar_sunang_thread(queue, date, lat, lon):
-    """
-    See sunang for input descriptions
-
-    Args:
-        queue: queue with cosz, azimuth
-        date: loop through dates to accesss queue, must be same as rest of queues
-
-    """
-
-    if 'cosz' not in queue.keys():
-        raise ValueError('queue must have cosz key')
-    if 'azimuth' not in queue.keys():
-        raise ValueError('queue must have cosz key')
-
-    log = logging.getLogger(__name__)
-
-    for t in date:
-
-        log.debug('%s Calculating sun angle' % t)
-
-        cosz, azimuth = pysolar_sunang(t.astimezone(pytz.utc), lat, lon)
 
         queue['cosz'].put([t, cosz])
         queue['azimuth'].put([t, azimuth])

--- a/smrf/envphys/radiation.py
+++ b/smrf/envphys/radiation.py
@@ -77,9 +77,9 @@ def albedo(telapsed, cosz, gsize, maxgsz, dirt=2):
         tuple:
         Returns a tuple containing the visible and IR spectral albedo
 
-        - alb_v (*numpy.array*) - albedo for visible specturm
+        - **alb_v** (*numpy.array*) - albedo for visible specturm
 
-        - alb_ir (*numpy.array*) -  albedo for ir spectrum
+        - **alb_ir** (*numpy.array*) -  albedo for ir spectrum
 
     Created April 17, 2015
     Modified July 23, 2015 - take image of cosz and calculate albedo for
@@ -160,9 +160,9 @@ def decay_alb_power(veg, veg_type, start_decay, end_decay, t_curr, pwr, alb_v, a
         tuple:
         Returns a tuple containing the corrected albedo arrays
         based on date, veg type
-        - alb_v (*numpy.array*) - albedo for visible specturm
+        - **alb_v** (*numpy.array*) - albedo for visible specturm
 
-        - alb_ir (*numpy.array*) -  albedo for ir spectrum
+        - **alb_ir** (*numpy.array*) -  albedo for ir spectrum
 
 
     Created July 18, 2017
@@ -195,13 +195,13 @@ def decay_alb_power(veg, veg_type, start_decay, end_decay, t_curr, pwr, alb_v, a
     else:
         # Use defaults
         max_dec = veg['default']
-        tao = (t_decay_hr) / (max_dec(1.0/pwr))
+        tao = (t_decay_hr) / (max_dec**(1.0/pwr))
         # Add default decay to array of zeros
         alb_dec = alb_dec + ((t_diff_hr) / tao)**pwr
         # Decay based on veg type
         for k,v in veg.items():
             max_dec = v
-            tao = (t_decay_hr) / (max_dec(1.0/pwr))
+            tao = (t_decay_hr) / (max_dec**(1.0/pwr))
             # Set albedo decay at correct veg types
             if isint(k):
                 alb_dec[veg_type == int(k)] = ((t_diff_hr) / tao)**pwr
@@ -240,9 +240,9 @@ def decay_alb_hardy(litter, veg_type, storm_day, alb_v, alb_ir):
         tuple:
         Returns a tuple containing the corrected albedo arrays
         based on date, veg type
-        - alb_v (*numpy.array*) - albedo for visible specturm
+        - **alb_v** (*numpy.array*) - albedo for visible specturm
 
-        - alb_ir (*numpy.array*) -  albedo for ir spectrum
+        - **alb_ir** (*numpy.array*) -  albedo for ir spectrum
 
     Created July 19, 2017
     Micah Sandusky
@@ -254,13 +254,13 @@ def decay_alb_hardy(litter, veg_type, storm_day, alb_v, alb_ir):
     l_rate = litter['default']
     alb_litter = litter['albedo']
 
-    sc = sc + (1.0-l_rate)(storm_day)
+    sc = sc + (1.0-l_rate)**(storm_day)
     # calculate snow coverage based on veg type
     for k, v in litter.items():
         #self._logger.debug('litter {0}: {1}'.format(v, self.config['litter'][v] ) )
         l_rate = litter[k]
         if isint(k):
-            sc[veg_type == int(k)] = (1.0 - l_rate)(storm_day[veg_type == int(k)])
+            sc[veg_type == int(k)] = (1.0 - l_rate)**(storm_day[veg_type == int(k)])
     # calculate litter coverage
     lc = np.ones_like(alb_v) - sc
     # weighted average to find decayed albedo
@@ -503,7 +503,7 @@ def hor1f(x, z, offset=1):
 
         # Start with next-to-adjacent point in either forward or backward
         # direction, depending on which way loop is running. Note that we
-        # don't consider the adjacent point this seems to help reduce noise.
+        # don't consider the adjacent point; this seems to help reduce noise.
         k = i + offset
 
         if k >= N:
@@ -519,14 +519,14 @@ def hor1f(x, z, offset=1):
             sij = _slope(x[i], zi, x[j], z[j])
             sihj = _slope(x[i], zi, x[k], z[k])
 
-            # if slope(i,j) >= slope(i,h[j]), horizon has been found otherwise
+            # if slope(i,j) >= slope(i,h[j]), horizon has been found; otherwise
             # set j to k (=h[j]) and loop again
             # or if we are at the end of the section
             if sij > sihj:  # or k == N-1:
                 break
 
-        # if slope(i,j) > slope(j,h[j]), j is i's horizon else if slope(i,j)
-        # is zero, i is its own horizon otherwise slope(i,j) = slope(i,h[j])
+        # if slope(i,j) > slope(j,h[j]), j is i's horizon; else if slope(i,j)
+        # is zero, i is its own horizon; otherwise slope(i,j) = slope(i,h[j])
         # so h[j] is i's horizon
         if sij > sihj:
             h[i] = j
@@ -859,7 +859,7 @@ def twostream(mu0, S0, tau=0.2, omega=0.85, g=0.3, R0=0.5, d=False):
 
     Args:
         mu0 - The cosine of the incidence angle is cos (from program sunang).
-        0 - Do not force an error if mu0 is <= 0.0 set all outputs to 0.0 and
+        0 - Do not force an error if mu0 is <= 0.0; set all outputs to 0.0 and
             go on. Program will fail if incidence angle is <= 0.0, unless -0
             has been set.
         tau - The optical depth is tau.  0 implies an infinite optical depth.

--- a/smrf/envphys/radiation.py
+++ b/smrf/envphys/radiation.py
@@ -198,14 +198,14 @@ def decay_alb_power(veg, veg_type, start_decay, end_decay, t_curr, pwr, alb_v, a
         max_dec = veg['default']
         tao = (t_decay_hr) / (max_dec(1.0/pwr))
         # Add default decay to array of zeros
-        alb_dec = alb_dec + ((t_diff_hr) / tao)pwr
+        alb_dec = alb_dec + ((t_diff_hr) / tao)**pwr
         # Decay based on veg type
         for k,v in veg.items():
             max_dec = v
             tao = (t_decay_hr) / (max_dec(1.0/pwr))
             # Set albedo decay at correct veg types
             if isint(k):
-                alb_dec[veg_type == int(k)] = ((t_diff_hr) / tao)pwr
+                alb_dec[veg_type == int(k)] = ((t_diff_hr) / tao)**pwr
                 # self._logger.debug('Type {0}, decay {1}'.format(int(v), veg_type['veg'][v]))
 
     alb_v_d = alb_v - alb_dec
@@ -565,7 +565,7 @@ def _cosz(x1, z1, x2, z2):
 
     20150601 Scott Havens
     """
-    d = np.sqrt((x2 - x1)2 + (z2 - z1)2)
+    d = np.sqrt((x2 - x1)**2 + (z2 - z1)**2)
     diff = z2 - z1
 
 #     v = np.where(diff != 0., d/diff, 100)
@@ -853,7 +853,7 @@ def cf_cloud(beam, diffuse, cf):
     CCOEF = 1.38
 
     # cloud attenuation, beam ratio is reduced
-    bf_c = CCOEF * (cf - CRAT1)2
+    bf_c = CCOEF * (cf - CRAT1)**2
     c_grad = beam * cf
     c_brad = c_grad * bf_c
     c_drad = c_grad - c_brad
@@ -1137,215 +1137,3 @@ def get_hrrr_cloud(df_solar, df_meta, logger, lat, lon):
 
 
 
-def dsign(a, b):
-    """
-    modified from /usr/src/lib/libF77/d_sign.c
-    """
-
-	x = a if a >= 0 else -a
-    y = x if b >= 0 then -x)
-	return y
-
-
-# original ibm 360/44 fortran ivf - vislab - wilson - 29jul79
-# translated, modified and reduced by dozier - ucsb - 11/81
-
-def ephemeris(dt, r):
-    """
-    NAME
-        ephemeris - calculates ephemeris data
-
-    SYNOPSIS
-        #include "solar.h"
-
-        int
-        ephemeris(
-            datetime_t  *dt,	|* date-time (GMT)		 *|
-            double      *r,		|* radius vector		 *|
-            double      *declin,	|* declination (radians, +north) *|
-            double      *omega)	|* sun longitude (radians +east) *|
-
-    DESCRIPTION
-        Calculates radius vector, declination, and apparent longitude
-        of sun, as function of the given date and time.
-
-        The routine is adapted from:
-
-        W. H. Wilson, Solar ephemeris algorithm, Reference 80-13, 70
-            pp., Scripps Institution of Oceanography, University of
-            California, San Diego, La Jolla, CA, 1980.
-
-    RETURN VALUE
-        OK	calculations succeeded, and output parameters assigned.
-
-        ERROR   error occurred, and message stored via 'usrerr' routine.
-    """
-    JULIAN_CENTURY = 36525		# days in Julian century
-    DEGS_IN_CIRCLE = 360        # degrees in circle
-#define	TOLERANCE	FLT_EPSILON
-
-	one = 1
-	degrd = atan(one) / 45
-
-    # Convert time to seconds since midnight
-	gmts = HR_TO_SEC(dt->hour) + MIN_TO_SEC(dt->min) + dt->sec
-
-    # p51 = gmts/3600/24*360
-
-	p51 = gmts / 10.0 / 24.0
-	p22 = ((dt->year - 1900) * JULIAN_CENTURY - 25) / 100
-	      + yearday(dt->year, dt->month, dt->day) - 0.5
-	p23 = (p51 / DEGS_IN_CIRCLE + p22) / JULIAN_CENTURY
-	p22 = p23 * JULIAN_CENTURY
-
-    # mean longitude - p24
-	p11 = 279.69668
-	p12 = 0.9856473354
-	p13 = 3.03e-4
-	p24 = p11 + fmod(p12 * p22, DEGS_IN_CIRCLE) + p13 * p23 * p23
-	p24 = fmod(p24, DEGS_IN_CIRCLE)
-
-    # mean anomaly - p25
-	p11 = 358.47583
-	p12 = 0.985600267
-	p13 = -1.5e-4
-	p14 = -3.e-6
-	p25 = p11 + fmod(p12 * p22, DEGS_IN_CIRCLE)
-		  + p23 * p23 * (p13 + p14 * p23)
-	p25 = fmod(p25, DEGS_IN_CIRCLE)
- 
-    # eccentricity - p26
-	p11 = 0.01675104
-	p12 = -4.18e-5
-	p13 = -1.26e-7
-	p26 = p11 + p23 * (p12 + p13 * p23)
-	p11 = p25 * degrd
-	p12 = p11
-
-	do {
-		p13 = p12
-		p12 = p11 + p26 * sin(p13)
-	}
-	while (fabs((p12 - p13) / p12) > TOLERANCE)
-
-	p13 = p12 / degrd
-
-    # true anomaly - p27
-	p27 = 2.0 * atan(sqrt((1.0 + p26) / (1.0 - p26))
-			 * tan(p13 / 2.0 * degrd)) / degrd
-	if (dsign(1.0, p27) != dsign(1.0, sin(p13 * degrd)))
-		p27 += 1.8e2
-	if (p27 < 0.0)
-		p27 += DEGS_IN_CIRCLE
- 
-    # radius vector - r
-	r = 1.0 - p26 * cos(p13 * degrd)
-
-    # aberration - p29
-	p29 = SEC_TO_HR(-20.47 / (*r))
- 
-    # mean obliquity - p43
-	p11 = 23.452294
-	p12 = -0.0130125
-	p13 = -1.64e-6
-	p14 = 5.03e-7
-	p43 = p11 + p23 * (p12 + p23 * (p13 + p14 * p23))
- 
-    #  mean ascension - p45
-	p11 = 279.6909832
-	p12 = 0.98564734
-	p13 = 3.8707
-	p13 = 3.8708e-4
-	p45 = p11 + fmod(p12 * p22, DEGS_IN_CIRCLE) + p13 * p23 * p23
-	p45 = fmod(p45, DEGS_IN_CIRCLE)
- 
-    # nutation and longitude pert
-	p11 = 296.104608
-	p12 = 1325 * DEGS_IN_CIRCLE
-	p13 = 198.8491083
-	p14 = 0.00919167
-	p15 = 1.4388e-5
-	p28 = p11 + fmod(p12 * p23, DEGS_IN_CIRCLE)
-		+ p23 * (p13 + p23 * (p14 + p15 * p23))
-	p28 = fmod(p28, DEGS_IN_CIRCLE)
- 
-    # mean elongation of moon - p30
-	p11 = 350.737486
-	p12 = 1236 * DEGS_IN_CIRCLE
-	p13 = 307.1142167
-	p14 = 1.436e-3
-	p30 = p11 + fmod(p12 * p23, DEGS_IN_CIRCLE) + p23 * (p13 + p14 * p23)
-	p30 = fmod(p30, DEGS_IN_CIRCLE)
- 
-    # moon long of ascending node - p31
-	p11 = 259.183275
-	p12 = -5 * DEGS_IN_CIRCLE
-	p13 = -134.142008
-	p14 = 2.0778e-3
-	p31 = p11 + fmod(p12 * p23, DEGS_IN_CIRCLE) + p23 * (p13 + p14 * p23)
-	p31 = fmod(p31, DEGS_IN_CIRCLE)
- 
-    # mean long of moon - p31
-	p11 = 270.434164
-	p12 = 1336 * DEGS_IN_CIRCLE
-	p13 = 307.8831417
-	p14 = -1.1333e-3
-	p32 = p11 + fmod(p12 * p23, DEGS_IN_CIRCLE) + p23 * (p13 + p14 * p23)
-	p32 = fmod(p32, DEGS_IN_CIRCLE)
- 
-    # moon perturbation of sun long - p33
-	p33 = 6.454 * sin(p30 * degrd) + 0.013 * sin(3 * p30 * degrd) +
-		0.177 * sin((p30 + p28) * degrd) -
-		0.424 * sin((p30 - p28) * degrd)
-	p33 = SEC_TO_HR(p33)
- 
-    # nutation of long - p34
-	p34 = -(17.234 - 0.017 * p23) * sin(p31 * degrd) +
-		0.209 * sin(2 * p31 * degrd) -
-		0.204 * sin(2 * p32 * degrd)
-	p34 = p34 - 1.257 * sin(2 * p24 * degrd) + 0.127 * sin(p28 * degrd)
-	p34 = SEC_TO_HR(p34)
- 
-    # nutation in obliquity - p34
-	p35 = 9.214 * cos(p31 * degrd) + 0.546 * cos(2 * p24 * degrd) -
-		.09 * cos(2 * p31 * degrd) + 0.088 * cos(2 * p32 * degrd)
-	p35 = SEC_TO_HR(p35)
- 
-    # inequalities of long period - p36
-	p36 = 0.266 * sin((31.8 + 119 * p23) * degrd) +
-		((1.882 - 0.016 * p23) * degrd) *
-		sin((57.24 + 150.27 * p23) * degrd)
-	p36 = p36 + 0.202 * sin((315.6 + 893.3 * p23) * degrd) +
-		1.089 * p23 * p23 + 6.4 * sin((231.19 + 20.2 * p23) * degrd)
-	p36 = SEC_TO_HR(p36)
-
-    # apparent longitude - p41
-	p41 = p27 - p25 + p24 + p29 + p33 + p36 + p34
-
-	p43 += p35
- 
-    # apparent right ascension - p44
-	p44 = atan(tan(p41 * degrd) * cos(p43 * degrd)) / degrd
-	if (dsign(one, p44) != dsign(one, sin(p41 * degrd)))
-		p44 += 1.8e2
-	if (p44 < 0.)
-		p44 += DEGS_IN_CIRCLE
-
-    # equation of time - p46
-	p46 = p45 - p44
-	if (p46 > 1.8e2)
-		p46 -= DEGS_IN_CIRCLE
-
-    # declination - p47
-	p47 = asin(sin(p41 * degrd) * sin(p43 * degrd))
-	declin = p47
- 
-    # hour angle in degrees - p48
-	p48 = p51 + p46 - 1.8e2
-	if (p48 > 180)
-		p48 -= DEGS_IN_CIRCLE
-	else if (p48 < -180)
-		p48 += DEGS_IN_CIRCLE
-	omega = -p48 * degrd
-
-	return declin, omega

--- a/smrf/envphys/sunang.py
+++ b/smrf/envphys/sunang.py
@@ -33,7 +33,7 @@ def sunang(date_time, latitude, longitude, truncate=True):
 
     azimuth = azimuth * 180 / M_PI
 
-    if truncate:
+    if truncate and not isinstance(mu, np.ndarray):
         mu = float('{0:.6f}'.format(mu))
         azimuth = float('{0:.5g}'.format(azimuth))
         rad_vec = float('{0:.5g}'.format(rad_vec))
@@ -80,11 +80,19 @@ def sunpath(latitude, longitude, declination, omega):
         cosz, azimuth in radians
     """
 
-    if np.abs(latitude) > M_PI_2:
-        raise ValueError("latitude ({} deg) not between -90 and +90 degrees".format(latitude*180/M_PI))
+    if isinstance(latitude, np.ndarray):
+        if np.any(np.abs(latitude) > M_PI_2):
+            raise ValueError("latitude array not between -90 and +90 degrees")
 
-    if np.abs(longitude) > M_PI:
-        raise ValueError("longitude ({} deg) not between -180 and +180 degrees".format(longitude*180/M_PI))
+        if np.any(np.abs(longitude) > M_PI):
+            raise ValueError("longitude array not between -180 and +180 degrees")
+
+    else:
+        if np.abs(latitude) > M_PI_2:
+            raise ValueError("latitude ({} deg) not between -90 and +90 degrees".format(latitude*180/M_PI))
+
+        if np.abs(longitude) > M_PI:
+            raise ValueError("longitude ({} deg) not between -180 and +180 degrees".format(longitude*180/M_PI))
 
     if np.abs(declination) > M_PI*MAX_DECLINATION/180:
         raise ValueError("declination ({} deg) > maximum declination ({} deg)".format(declination*180/M_PI, MAX_DECLINATION))
@@ -354,14 +362,22 @@ def rotate(mu, azm, mu_r, lam_r):
     if mu < -1.0 or mu > 1.0:
         raise ValueError("rotate: mu = cos(theta) = {} is not between -1 and +1".format(mu))
 
-    if mu_r < -1.0 or mu_r > 1.0:
-        raise ValueError("rotate: mu_rotate = cos(theta-sub-r) = {} is not between -1 and +1".format(mu_r))
+    if isinstance(mu_r, np.ndarray):
+        if np.any(mu_r < -1.0) or np.any(mu_r > 1.0):
+            raise ValueError("rotate, mu_r array is not between -1 and +1")
+    else:
+        if mu_r < -1.0 or mu_r > 1.0:
+            raise ValueError("rotate: mu_rotate = cos(theta-sub-r) = {} is not between -1 and +1".format(mu_r))
 
     if np.abs(azm) > (2 * np.pi):
         raise ValueError("rotate: azimuth ({} deg) is not between -360 and 360".format(180 * (azm * 360) / np.pi))
 
-    if np.abs(lam_r) > (2 * np.pi):
-        raise ValueError("rotate: lam_r ({} deg) = axis rotation, is not between -360 and 360".format(180 * lam_r / np.pi))
+    if isinstance(lam_r, np.ndarray):
+        if np.any(np.abs(lam_r) > (2 * np.pi)):
+            raise ValueError("rotate, lam_r array is not between -360 and 360")
+    else:
+        if np.abs(lam_r) > (2 * np.pi):
+            raise ValueError("rotate: lam_r ({} deg) = axis rotation, is not between -360 and 360".format(180 * lam_r / np.pi))
 
     # difference between azimuth and rotation angle of x-axis
     omega = lam_r - azm
@@ -377,15 +393,12 @@ def rotate(mu, azm, mu_r, lam_r):
     #Output:
     #azimuth and cosine of angle in rotated axis system.
     #(bug if trig routines trigger error)
-    aPrime = -np.arctan2(sinTheta * sin(omega),
+    aPrime = -np.arctan2(sinTheta * np.sin(omega),
                 mu_r * sinTheta * cosOmega - mu * sinThr)
     muPrime = sinTheta * sinThr * cosOmega + mu * mu_r
     
     return muPrime, aPrime
 
-
-
- 
 
 def yearday(year, month, day):
     """

--- a/smrf/envphys/sunang.py
+++ b/smrf/envphys/sunang.py
@@ -1,0 +1,454 @@
+import numpy as np
+from math import fmod, tan, atan, cos, sin, asin, sqrt
+
+JULIAN_CENTURY = 36525		# days in Julian century
+DEGS_IN_CIRCLE = 3.6e2        # degrees in circle
+TOLERANCE = 1.1920928955e-07
+M_PI = 3.14159265358979323846
+M_PI_2 = 2 * M_PI
+MAX_DECLINATION = 23.6
+
+
+def sunang(date_time, latitude, longitude):
+    """
+    Args:
+        date_time: python datetime object
+        latitude: in degrees
+        longitude: in degrees
+
+    Returns
+        cosz, azimuth
+    """
+
+    # Calculate the ephemeris parameters
+    declination, omega, rad_vec = ephemeris(date_time)
+
+    # calculate the sun angle
+    rad_latitude = latitude * M_PI /180
+    rad_longitude = longitude * M_PI / 180
+    mu, azimuth = sunpath(rad_latitude, rad_longitude, declination, omega)
+
+    azimuth = azimuth * 180 / M_PI
+
+    return mu, azimuth, rad_vec
+
+
+def sunpath(latitude, longitude, declination, omega):
+    """
+    Args:
+        latitude: in radians
+        longitude: in radians
+        declination
+        omega
+
+    Returns
+        cosz, azimuth in radians
+    """
+
+    if np.abs(latitude) > M_PI_2:
+        raise ValueError("latitude ({} deg) not between -90 and +90 degrees".format(latitude*180/M_PI))
+
+    if np.abs(longitude) > M_PI:
+        raise ValueError("longitude ({} deg) not between -180 and +180 degrees".format(longitude*180/M_PI))
+
+    if np.abs(declination) > M_PI*MAX_DECLINATION/180:
+        raise ValueError("declination ({} deg) > maximum declination ({} deg)".format(declination*180/M_PI, MAX_DECLINATION))
+
+    if np.abs(omega) > M_PI:
+        raise ValueError("longitude of sun ({} deg) not between -180 and +180 degrees".format(omega*180/M_PI))
+
+    cosz, az = rotate(np.sin(declination), omega, np.sin(latitude), longitude)
+
+    return cosz, az
+
+def dsign(a, b):
+    """
+    modified from /usr/src/lib/libF77/d_sign.c
+    """
+    
+    x = a if a >= 0 else -a
+    y = x if b >= 0 else -x
+    return y
+
+# original ibm 360/44 fortran ivf - vislab - wilson - 29jul79
+# translated, modified and reduced by dozier - ucsb - 11/81
+
+def ephemeris(dt):
+    """
+    NAME
+        ephemeris - calculates ephemeris data
+
+    SYNOPSIS
+        #include "solar.h"
+
+        int
+        ephemeris(
+            datetime_t  *dt,	|* date-time (GMT)		 *|
+            double      *r,		|* radius vector		 *|
+            double      *declin,	|* declination (radians, +north) *|
+            double      *omega)	|* sun longitude (radians +east) *|
+
+    DESCRIPTION
+        Calculates radius vector, declination, and apparent longitude
+        of sun, as function of the given date and time.
+
+        The routine is adapted from:
+
+        W. H. Wilson, Solar ephemeris algorithm, Reference 80-13, 70
+            pp., Scripps Institution of Oceanography, University of
+            California, San Diego, La Jolla, CA, 1980.
+
+    RETURN VALUE
+        OK	calculations succeeded, and output parameters assigned.
+
+        ERROR   error occurred, and message stored via 'usrerr' routine.
+    """
+        
+    one = 1.0
+    degrd = atan(one) / 45.0
+
+    # Convert time to seconds since midnight
+    gmts = 3600.0 * dt.hour + 60.0 * dt.minute + dt.second
+
+    # p51 = gmts/3600/24*360
+
+    # The int() is required for compatability with IPW as the divide by 100 keeps
+    # the value as an integer where python converts to a float...
+    p51 = gmts / 10.0 / 24.0
+    p22 = int(((dt.year - 1900) * JULIAN_CENTURY - 25) / 100) + yearday(dt.year, dt.month, dt.day) - 0.5
+    p23 = (p51 / DEGS_IN_CIRCLE + p22) / JULIAN_CENTURY
+    p22 = p23 * JULIAN_CENTURY
+
+    # mean longitude - p24
+    p11 = 279.69668
+    p12 = 0.9856473354
+    p13 = 3.03e-4
+    p24 = p11 + fmod(p12 * p22, DEGS_IN_CIRCLE) + p13 * p23 * p23
+    p24 = fmod(p24, DEGS_IN_CIRCLE)
+
+    # mean anomaly - p25
+    p11 = 358.47583
+    p12 = 0.985600267
+    p13 = -1.5e-4
+    p14 = -3.e-6
+    p25 = p11 + fmod(p12 * p22, DEGS_IN_CIRCLE) + p23 * p23 * (p13 + p14 * p23)
+    p25 = fmod(p25, DEGS_IN_CIRCLE)
+ 
+    # eccentricity - p26
+    p11 = 0.01675104
+    p12 = -4.18e-5
+    p13 = -1.26e-7
+    p26 = p11 + p23 * (p12 + p13 * p23)
+    p11 = p25 * degrd
+    p12 = p11
+
+    while True:
+        p13 = p12
+        p12 = p11 + p26 * sin(p13)
+        if abs((p12 - p13) / p12) < TOLERANCE:
+            break
+
+    p13 = p12 / degrd
+
+    # true anomaly - p27`
+    p27 = 2.0 * atan(sqrt((1.0 + p26) / (1.0 - p26)) * tan(p13 / 2.0 * degrd)) / degrd
+    if dsign(1.0, p27) != dsign(1.0, sin(p13 * degrd)):
+        p27 += 1.8e2
+    if p27 < 0.0:
+        p27 += DEGS_IN_CIRCLE
+ 
+    # radius vector - r
+    r = 1.0 - p26 * cos(p13 * degrd)
+
+    # aberration - p29
+    p29 = -20.47 / r / 3600
+
+    # mean obliquity - p43
+    p11 = 23.452294
+    p12 = -0.0130125
+    p13 = -1.64e-6
+    p14 = 5.03e-7
+    p43 = p11 + p23 * (p12 + p23 * (p13 + p14 * p23))
+ 
+    #  mean ascension - p45
+    p11 = 279.6909832
+    p12 = 0.98564734
+    p13 = 3.8707
+    p13 = 3.8708e-4
+    p45 = p11 + fmod(p12 * p22, DEGS_IN_CIRCLE) + p13 * p23 * p23
+    p45 = fmod(p45, DEGS_IN_CIRCLE)
+
+    # nutation and longitude pert
+    p11 = 296.104608
+    p12 = 1325 * DEGS_IN_CIRCLE
+    p13 = 198.8491083
+    p14 = 0.00919167
+    p15 = 1.4388e-5
+    p28 = p11 + fmod(p12 * p23, DEGS_IN_CIRCLE) + p23 * (p13 + p23 * (p14 + p15 * p23))
+    p28 = fmod(p28, DEGS_IN_CIRCLE)
+
+    # mean elongation of moon - p30
+    p11 = 350.737486
+    p12 = 1236 * DEGS_IN_CIRCLE
+    p13 = 307.1142167
+    p14 = 1.436e-3
+    p30 = p11 + fmod(p12 * p23, DEGS_IN_CIRCLE) + p23 * (p13 + p14 * p23)
+    p30 = fmod(p30, DEGS_IN_CIRCLE)
+
+    # moon long of ascending node - p31
+    p11 = 259.183275
+    p12 = -5 * DEGS_IN_CIRCLE
+    p13 = -134.142008
+    p14 = 2.0778e-3
+    p31 = p11 + fmod(p12 * p23, DEGS_IN_CIRCLE) + p23 * (p13 + p14 * p23)
+    p31 = fmod(p31, DEGS_IN_CIRCLE)
+
+    # mean long of moon - p31
+    p11 = 270.434164
+    p12 = 1336 * DEGS_IN_CIRCLE
+    p13 = 307.8831417
+    p14 = -1.1333e-3
+    p32 = p11 + fmod(p12 * p23, DEGS_IN_CIRCLE) + p23 * (p13 + p14 * p23)
+    p32 = fmod(p32, DEGS_IN_CIRCLE)
+
+    # moon perturbation of sun long - p33
+    p33 = 6.454 * sin(p30 * degrd) + 0.013 * sin(3 * p30 * degrd) + \
+        0.177 * sin((p30 + p28) * degrd) - \
+        0.424 * sin((p30 - p28) * degrd)
+    p33 = p33 / 3600
+
+    # nutation of long - p34
+    p34 = -(17.234 - 0.017 * p23) * sin(p31 * degrd) + \
+        0.209 * sin(2 * p31 * degrd) - \
+        0.204 * sin(2 * p32 * degrd)
+    p34 = p34 - 1.257 * sin(2 * p24 * degrd) + 0.127 * sin(p28 * degrd)
+    p34 = p34 / 3600
+
+    # nutation in obliquity - p34
+    p35 = 9.214 * cos(p31 * degrd) + 0.546 * cos(2 * p24 * degrd) - \
+        .09 * cos(2 * p31 * degrd) + 0.088 * cos(2 * p32 * degrd)
+    p35 = p35 / 3600
+
+    # inequalities of long period - p36
+    p36 = 0.266 * sin((31.8 + 119 * p23) * degrd) + \
+        ((1.882 - 0.016 * p23) * degrd) * \
+        sin((57.24 + 150.27 * p23) * degrd)
+    p36 = p36 + 0.202 * sin((315.6 + 893.3 * p23) * degrd) + \
+        1.089 * p23 * p23 + 6.4 * sin((231.19 + 20.2 * p23) * degrd)
+    p36 = p36 / 3600
+
+    # apparent longitude - p41
+    p41 = p27 - p25 + p24 + p29 + p33 + p36 + p34
+
+    p43 += p35
+
+    # apparent right ascension - p44
+    p44 = atan(tan(p41 * degrd) * cos(p43 * degrd)) / degrd
+    if dsign(one, p44) != dsign(one, sin(p41 * degrd)):
+        p44 += 1.8e2
+    if p44 < 0:
+        p44 += DEGS_IN_CIRCLE
+
+    # equation of time - p46
+    p46 = p45 - p44
+    if p46 > 1.8e2:
+        p46 -= DEGS_IN_CIRCLE
+
+    # declination - p47
+    p47 = asin(sin(p41 * degrd) * sin(p43 * degrd))
+    declin = p47
+
+    # hour angle in degrees - p48
+    p48 = p51 + p46 - 1.8e2
+    if p48 > 180:
+        p48 -= DEGS_IN_CIRCLE
+    elif p48 < -180:
+        p48 += DEGS_IN_CIRCLE
+    omega = -p48 * degrd
+
+    return declin, omega, r
+
+def rotate(mu, azm, mu_r, lam_r):
+    """
+    NAME
+	rotate - rotation of spherical coordinates
+
+    SYNOPSIS
+        #include "ipw.h"
+
+        int
+        rotate(
+            double    mu,		|* cosine of angle theta from z-axis *|
+            double    azm,		|* azimuth (+ccw from x-axis) 	     *|
+            double    mu_r,		|* cosine of angle theta_r of
+                        rotation of z-axis		     *|
+            double    lam_r,	|* azimuth (+ccw) of x-axis rotation *|
+            double   *muPrime,	|* new cosine of angle from z'-axis  *|
+            double   *aPrime)	|* new azimuth from x'-axis	     *|
+
+    DESCRIPTION
+        Calculates new spherical coordinates if system rotated about
+        origin.  Coordinates are right-hand system.  All angles are in
+        radians.
+
+        input --
+        mu	cosine of angle theta from z-axis in old coordinate system
+        azm	azimuth (+ccw from x-axis) in old coordinate system
+        mu_r	cosine of angle theta_r of rotation of z-axis
+        lam_r	azimuth (+ccw) of rotation of x-axis
+
+        output --
+        muPrime	new value of cosine of angle from z'-axis
+        aPrime	new value of azimuth from x'-axis
+
+        for example, to use this program to calculate sun angles, set:
+
+        mu	= sin(declination)
+        azm	= hour angle of sun (long. where sun is vertical)
+        mu_r	= sin(latitude)
+        lam_r	= longitude
+
+        output will be muPrime = cosZ and aPrime = solar azimuth
+
+    RETURN VALUE
+        cosZ
+        solar azimuth
+    """
+
+    # Check input values: mu = cos(theta) mu_r = cos(theta-sub-r)
+    if mu < -1.0 or mu > 1.0:
+        raise ValueError("rotate: mu = cos(theta) = {} is not between -1 and +1".format(mu))
+
+    if mu_r < -1.0 or mu_r > 1.0:
+        raise ValueError("rotate: mu_rotate = cos(theta-sub-r) = {} is not between -1 and +1".format(mu_r))
+
+    if np.abs(azm) > (2 * np.pi):
+        raise ValueError("rotate: azimuth ({} deg) is not between -360 and 360".format(180 * (azm * 360) / np.pi))
+
+    if np.abs(lam_r) > (2 * np.pi):
+        raise ValueError("rotate: lam_r ({} deg) = axis rotation, is not between -360 and 360".format(180 * lam_r / np.pi))
+
+    # difference between azimuth and rotation angle of x-axis
+    omega = lam_r - azm
+
+    #sine of angle theta (cosine is an argument)
+    #sine of angle theta-sub-r (cosine is an argument)
+    sinTheta = np.sqrt((1. - mu) * (1. + mu))
+    sinThr = np.sqrt((1. - mu_r) * (1. + mu_r))
+        
+    #cosine of difference between azimuth and aziumth of rotation
+    cosOmega = np.cos(omega)
+
+    #Output:
+    #azimuth and cosine of angle in rotated axis system.
+    #(bug if trig routines trigger error)
+    aPrime = -np.arctan2(sinTheta * sin(omega),
+                mu_r * sinTheta * cosOmega - mu * sinThr)
+    muPrime = sinTheta * sinThr * cosOmega + mu * mu_r
+    
+    return muPrime, aPrime
+
+
+
+ 
+
+def yearday(year, month, day):
+    """
+    NAME
+        yearday -- returns the yearday (day of year) for a given date
+
+    SYNOPSIS
+        #include "ipw.h"
+
+        int
+        yearday(
+            int 	year,		|* e.g., 1997		*|
+            int 	month,		|* [1 - 12]		*|
+            int 	day)		|* [1 - 31]		*|
+
+    DESCRIPTION
+        yearday returns the yearday for the given date.  yearday is
+        the 'day of the year', sometimes called (incorrectly) 'julian day'.
+
+    RETURN VALUE
+        1 - 366
+    """
+
+    assert(year >= 0)
+    assert(1 <= month and month <= 12)
+    assert(1 <= day and day <= numdays(year, month))
+
+    yday = day
+
+    # Add in number of days for preceeding months.
+    for mon in range(month-1, 0, -1):
+        yday += numdays(year, mon)
+
+    return yday
+
+
+def numdays(year, month):
+    """
+     NAME
+        numdays - return number of days in a month
+    
+    SYNOPSIS
+        #include "ipw.h"
+
+        int
+        numdays(
+            int		year,		|* year			*|
+            int		month)		|* month (1 to 12)	*|
+    
+    DESCRIPTION
+        numdays retuns the number of days in the given month of
+        the given year.
+    
+    RETURN VALUE
+        number of days in month
+    """
+
+    NDAYS = list([31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31])
+
+    assert(year >= 0)
+    assert(1 <= month and month <= 12)
+
+    ndays = NDAYS[month-1]
+
+    # Check for leap year for February
+    if ((month == 2) and leapyear(year)):
+        ndays += 1
+
+    return ndays
+
+
+def leapyear(year):
+    """
+    NAME
+        leapyear -- is a given year a leap year?
+
+    SYNOPSIS
+        #include "ipw.h"
+
+        bool_t
+        leapyear(
+            int 	year)
+
+    DESCRIPTION
+        leapyear determines if the given year is a leap year or not.
+        year must be positive, and must not be abbreviated; i.e.
+        89 is 89 A.D. not 1989.
+
+    RETURN VALUE
+        TRUE	if a leap year
+
+        FALSE	if not a leap year
+    """
+
+    assert(year >= 0)
+
+    if ((year % 4 == 0 and year % 100 != 0) or year % 400 == 0):
+        return True
+    else:
+        return False
+	

--- a/smrf/framework/model_framework.py
+++ b/smrf/framework/model_framework.py
@@ -544,12 +544,9 @@ class SMRF():
 
             self._logger.info('Distributing time step %s' % t)
             # 0.1 sun angle for time step
-            cosz, azimuth = radiation.sunang(t.astimezone(pytz.utc),
-                                             self.topo.topoConfig['basin_lat'],
-                                             self.topo.topoConfig['basin_lon'],
-                                             zone=0,
-                                             slope=0,
-                                             aspect=0)
+            cosz, azimuth = radiation.pysolar_sunang(t.astimezone(pytz.utc),
+                                                    self.topo.topoConfig['basin_lat'],
+                                                    self.topo.topoConfig['basin_lon'])
 
             # 0.2 illumination angle
             illum_ang = None
@@ -702,12 +699,11 @@ class SMRF():
         # Distribute the data
 
         # 0.1 sun angle for time step
-        t.append(Thread(target=radiation.sunang_thread,
+        t.append(Thread(target=radiation.pysolar_sunang_thread,
                         name='sun_angle',
                         args=(q, self.date_time,
                               self.topo.topoConfig['basin_lat'],
-                              self.topo.topoConfig['basin_lon'],
-                              0, 0, 0)))
+                              self.topo.topoConfig['basin_lon'])))
 
         # 0.2 illumination angle
         t.append(Thread(target=radiation.shade_thread,

--- a/smrf/framework/model_framework.py
+++ b/smrf/framework/model_framework.py
@@ -32,7 +32,7 @@ import pandas as pd
 import numpy as np
 import pytz
 from smrf import data, distribute, output, __core_config__, __recipes__
-from smrf.envphys import radiation
+from smrf.envphys import radiation, sunang
 from smrf.utils import queue, io
 from smrf.utils.utils import backup_input, getqotw, check_station_colocation
 from threading import Thread
@@ -544,9 +544,9 @@ class SMRF():
 
             self._logger.info('Distributing time step %s' % t)
             # 0.1 sun angle for time step
-            cosz, azimuth = radiation.pysolar_sunang(t.astimezone(pytz.utc),
-                                                    self.topo.topoConfig['basin_lat'],
-                                                    self.topo.topoConfig['basin_lon'])
+            cosz, azimuth, rad_vec = sunang.sunang(t.astimezone(pytz.utc),
+                                            self.topo.topoConfig['basin_lat'],
+                                            self.topo.topoConfig['basin_lon'])
 
             # 0.2 illumination angle
             illum_ang = None
@@ -699,7 +699,7 @@ class SMRF():
         # Distribute the data
 
         # 0.1 sun angle for time step
-        t.append(Thread(target=radiation.pysolar_sunang_thread,
+        t.append(Thread(target=sunang.sunang_thread,
                         name='sun_angle',
                         args=(q, self.date_time,
                               self.topo.topoConfig['basin_lat'],

--- a/tests/test_radiation.py
+++ b/tests/test_radiation.py
@@ -74,40 +74,42 @@ class TestRadiation(SMRFTestCase):
         self.assertEqual(round(r, 9), 0.987871247)
 
 
-    # The code that generated the figures in the PR for comparison
-    # between the IPW version and the Pysolar version
-    def test_sunang_timeseries(self):
-        """ Sunang calculation timeseries """ 
+    # # The code that generated the figures in the PR for comparison
+    # # between the IPW version and the Pysolar version
+    # def test_sunang_timeseries(self):
+    #     """ Sunang calculation timeseries """ 
 
-        # RME basin lat/lon
-        lon = -116.7547
-        lat = 43.067
+    #     # RME basin lat/lon
+    #     lon = -116.7547
+    #     lat = 43.067
 
-        date_time = pd.date_range('2015-10-01 00:00', '2016-09-30 00:00', freq='H', tz='UTC')
+    #     date_time = pd.date_range('2015-10-01 00:00', '2016-09-30 00:00', freq='H', tz='UTC')
         
-        df = pd.DataFrame(
-            index=date_time,
-            columns=['ipw_cosz', 'ipw_az', 'py_cosz', 'py_az']
-            )
+    #     df = pd.DataFrame(
+    #         index=date_time,
+    #         columns=['ipw_cosz', 'ipw_az', 'py_cosz', 'py_az']
+    #         )
 
-        for dt in date_time:
-            print(dt)
-            result = radiation.sunang(dt, lat, lon)
-            df.loc[dt, ['ipw_cosz', 'ipw_az']] = result
+    #     for dt in date_time:
+    #         print(dt)
+    #         result = radiation.sunang(dt, lat, lon)
+    #         df.loc[dt, ['ipw_cosz', 'ipw_az']] = result
 
-            result = sunang.sunang(dt, lat, lon)
-            df.loc[dt, ['py_cosz', 'py_az']] = result
+    #         presult = sunang.sunang(dt, lat, lon)
+    #         # df.loc[dt, ['py_cosz', 'py_az']] = [round(presult[0], 6), round(presult[1], 3)]
+    #         df.loc[dt, ['py_cosz', 'py_az']] = presult[0:2]
 
-        df['zen_diff'] = (df['ipw_cosz'] - df['py_cosz']) * 180 / np.pi
-        df['az_diff'] = df['ipw_az'] - df['py_az']
+    #     df['zen_diff'] = (df['ipw_cosz'] - df['py_cosz']) * 180 / np.pi
+    #     df['az_diff'] = df['ipw_az'] - df['py_az']
 
-        df.to_csv('sunang_comparison.csv')
+    #     df.to_csv('sunang_comparison.csv')
 
-        ax = df['zen_diff'].hist(bins=50)
-        ax.set_title('IPW zenith - Python zenith')
-        ax.set_xlabel('Zenith difference, degrees')
+    #     ax = df['zen_diff'].hist(bins=50)
+    #     ax.set_title('IPW zenith - Python zenith')
+    #     ax.set_xlabel('Zenith difference, degrees')
         
-        ax = df['az_diff'].hist(bins=50)
-        ax.set_title('IPW azimuth - Python azimuth')
-        ax.set_xlabel('Azimuth difference, degrees')
+    #     ax = df['az_diff'].hist(bins=50)
+    #     ax.set_title('IPW azimuth - Python azimuth')
+    #     ax.set_xlabel('Azimuth difference, degrees')
+
         

--- a/tests/test_radiation.py
+++ b/tests/test_radiation.py
@@ -1,11 +1,12 @@
 from copy import deepcopy
-from inicheck.tools import cast_all_variables
-from inicheck.utilities import pcfg
 import unittest
 import pandas as pd
+import numpy as np
 
 from smrf.envphys import radiation
 from tests.test_configurations import SMRFTestCase
+
+from pysolar.solar import get_altitude, get_azimuth
 
 
 class TestRadiation(SMRFTestCase):
@@ -15,9 +16,29 @@ class TestRadiation(SMRFTestCase):
 
         # replicate the sun angle calculation from the sunang man page
         # for Santa Barbara on Feb 15, 1990 at 20:30 UTC
+        # The difference between IPW sunang and Pysolar for the following
+        # example are:
+        #           | IPW       | PySolar
+        # zenith    | 47.122    | 47.107
+        # cosz      | 0.680436  | 0.680631
+        # azimuth   | -5.413    | -5.416
+        #
+        # The differences for this one instance is hundredths of degrees
+        # in zenith and thousandths in azimuth
 
         date_time = pd.to_datetime('2/15/1990 20:30')
-        result = radiation.sunang(date_time, 34.416667, -119.9)       
+        date_time = date_time.tz_localize('UTC')
+        lat = 34.416667
+        lon = -119.9
+        cosz = 0.680436
+        zenith = 47.122
+        az = -5.413
+        result = radiation.sunang(date_time, lat, lon)
 
-        self.assertTrue(result[0] == 0.680436)
-        self.assertTrue(result[1] == -5.413)
+        self.assertTrue(result[0] == cosz)
+        self.assertTrue(result[1] == az)
+
+        result = radiation.pysolar_sunang(date_time, lat, lon)
+
+        self.assertTrue(result[0] == cosz)
+        self.assertTrue(result[1] == az)

--- a/tests/test_radiation.py
+++ b/tests/test_radiation.py
@@ -16,15 +16,15 @@ class TestRadiation(SMRFTestCase):
 
         # replicate the sun angle calculation from the sunang man page
         # for Santa Barbara on Feb 15, 1990 at 20:30 UTC
-        # The difference between IPW sunang and Pysolar for the following
-        # example are:
-        #           | IPW       | PySolar
-        # zenith    | 47.122    | 47.107
-        # cosz      | 0.680436  | 0.680631
-        # azimuth   | -5.413    | -5.416
+        # 
+        #           | IPW       
+        # zenith    | 47.122    
+        # cosz      | 0.680436
+        # azimuth   | -5.413
         #
-        # The differences for this one instance is hundredths of degrees
-        # in zenith and thousandths in azimuth
+        # The differences between the IPW version and python version
+        # are insignificant and are only different because of the
+        # values are pulled from stdout for IPW which uses printf
 
         date_time = pd.to_datetime('2/15/1990 20:30')
         date_time = date_time.tz_localize('UTC')
@@ -33,9 +33,6 @@ class TestRadiation(SMRFTestCase):
         ipw_cosz = 0.680436
         ipw_azimuth = -5.413
         ipw_rad_vector = 0.98787
-        cosz = 0.6806311288888297
-        zenith = 47.107
-        az = -5.416396416371043
         
         result = radiation.sunang(date_time, lat, lon)
         self.assertTrue(result[0] == ipw_cosz)
@@ -43,14 +40,9 @@ class TestRadiation(SMRFTestCase):
 
         # try out the python version
         result = sunang.sunang(date_time, lat, lon)
-        self.assertTrue(round(result[0], 6), ipw_cosz)
-        self.assertTrue(round(result[1], 3), ipw_azimuth)
-        self.assertTrue(round(result[2], 5), ipw_rad_vector)
-
-
-        # result = radiation.pysolar_sunang(date_time, lat, lon)
-        # self.assertTrue(result[0] == cosz)
-        # self.assertTrue(result[1] == az)
+        self.assertTrue(result[0], ipw_cosz)
+        self.assertTrue(result[1], ipw_azimuth)
+        self.assertTrue(result[2], ipw_rad_vector)
 
     
     def test_sunang_functions(self):

--- a/tests/test_radiation.py
+++ b/tests/test_radiation.py
@@ -1,0 +1,23 @@
+from copy import deepcopy
+from inicheck.tools import cast_all_variables
+from inicheck.utilities import pcfg
+import unittest
+import pandas as pd
+
+from smrf.envphys import radiation
+from tests.test_configurations import SMRFTestCase
+
+
+class TestRadiation(SMRFTestCase):
+
+    def test_sunang(self):
+        """ Sunang calculation """
+
+        # replicate the sun angle calculation from the sunang man page
+        # for Santa Barbara on Feb 15, 1990 at 20:30 UTC
+
+        date_time = pd.to_datetime('2/15/1990 20:30')
+        result = radiation.sunang(date_time, 34.416667, -119.9)       
+
+        self.assertTrue(result[0] == 0.680436)
+        self.assertTrue(result[1] == -5.413)

--- a/tests/test_radiation.py
+++ b/tests/test_radiation.py
@@ -30,15 +30,53 @@ class TestRadiation(SMRFTestCase):
         date_time = date_time.tz_localize('UTC')
         lat = 34.416667
         lon = -119.9
-        cosz = 0.680436
-        zenith = 47.122
-        az = -5.413
-        result = radiation.sunang(date_time, lat, lon)
-
-        self.assertTrue(result[0] == cosz)
-        self.assertTrue(result[1] == az)
+        cosz = 0.6806311288888297
+        zenith = 47.107
+        az = -5.416396416371043
+        
+        # result = radiation.sunang(date_time, lat, lon)
+        # self.assertTrue(result[0] == cosz)
+        # self.assertTrue(result[1] == az)
 
         result = radiation.pysolar_sunang(date_time, lat, lon)
-
         self.assertTrue(result[0] == cosz)
         self.assertTrue(result[1] == az)
+
+
+    # The code that generated the figures in the PR for comparison
+    # between the IPW version and the Pysolar version
+    # def test_sunang_timeseries(self):
+    #     """ Sunang calculation timeseries """ 
+
+    #     # RME basin lat/lon
+    #     lon = -116.7547
+    #     lat = 43.067
+
+    #     date_time = pd.date_range('2015-10-01 00:00', '2016-09-30 00:00', freq='H', tz='UTC')
+        
+    #     df = pd.DataFrame(
+    #         index=date_time,
+    #         columns=['ipw_cosz', 'ipw_az', 'pysolar_cosz', 'pysolar_az']
+    #         )
+
+    #     for dt in date_time:
+    #         print(dt)
+    #         result = radiation.sunang(dt, lat, lon)
+    #         df.loc[dt, ['ipw_cosz', 'ipw_az']] = result
+
+    #         result = radiation.pysolar_sunang(dt, lat, lon)
+    #         df.loc[dt, ['pysolar_cosz', 'pysolar_az']] = result
+
+    #     df['zen_diff'] = (df['ipw_cosz'] - df['pysolar_cosz']) * 180 / np.pi
+    #     df['az_diff'] = df['ipw_az'] - df['pysolar_az']
+
+    #     df.to_csv('sunang_comparison.csv')
+
+    #     ax = df['zen_diff'].hist(bins=50)
+    #     ax.set_title('IPW zenith - Pysolar zenith')
+    #     ax.set_xlabel('Zenith difference, degrees')
+        
+    #     ax = df['az_diff'].hist(bins=50)
+    #     ax.set_title('IPW azimuth - Pysolar azimuth')
+    #     ax.set_xlabel('Azimuth difference, degrees')
+        

--- a/tests/test_radiation.py
+++ b/tests/test_radiation.py
@@ -3,7 +3,7 @@ import unittest
 import pandas as pd
 import numpy as np
 
-from smrf.envphys import radiation
+from smrf.envphys import radiation, sunang
 from tests.test_configurations import SMRFTestCase
 
 from pysolar.solar import get_altitude, get_azimuth
@@ -28,55 +28,86 @@ class TestRadiation(SMRFTestCase):
 
         date_time = pd.to_datetime('2/15/1990 20:30')
         date_time = date_time.tz_localize('UTC')
-        lat = 34.416667
+        lat = 34.4166667 # 35d, 25m, 0s
         lon = -119.9
+        ipw_cosz = 0.680436
+        ipw_azimuth = -5.413
+        ipw_rad_vector = 0.98787
         cosz = 0.6806311288888297
         zenith = 47.107
         az = -5.416396416371043
         
-        # result = radiation.sunang(date_time, lat, lon)
+        result = radiation.sunang(date_time, lat, lon)
+        self.assertTrue(result[0] == ipw_cosz)
+        self.assertTrue(result[1] == ipw_azimuth)
+
+        # try out the python version
+        result = sunang.sunang(date_time, lat, lon)
+        self.assertTrue(round(result[0], 6), ipw_cosz)
+        self.assertTrue(round(result[1], 3), ipw_azimuth)
+        self.assertTrue(round(result[2], 5), ipw_rad_vector)
+
+
+        # result = radiation.pysolar_sunang(date_time, lat, lon)
         # self.assertTrue(result[0] == cosz)
         # self.assertTrue(result[1] == az)
 
-        result = radiation.pysolar_sunang(date_time, lat, lon)
-        self.assertTrue(result[0] == cosz)
-        self.assertTrue(result[1] == az)
+    
+    def test_sunang_functions(self):
+        """ Sunang functions """
+
+        self.assertTrue(sunang.leapyear(2016))
+        self.assertFalse(sunang.leapyear(2013))
+
+        self.assertEqual(sunang.yearday(2016, 1, 31), 31)
+        self.assertEqual(sunang.yearday(2016, 12, 31), 366)
+        self.assertEqual(sunang.yearday(2015, 12, 31), 365)
+        self.assertEqual(sunang.yearday(2015, 10, 1), 274)
+        self.assertEqual(sunang.yearday(2016, 10, 1), 275)
+
+        # replicating the IPW sunang example
+        date_time = pd.to_datetime('2/15/1990 20:30')
+        date_time = date_time.tz_localize('UTC')
+        declin, omega, r = sunang.ephemeris(date_time)
+        self.assertEqual(round(declin, 9), -0.218992538)
+        self.assertEqual(round(omega, 9), -2.163529935)
+        self.assertEqual(round(r, 9), 0.987871247)
 
 
     # The code that generated the figures in the PR for comparison
     # between the IPW version and the Pysolar version
-    # def test_sunang_timeseries(self):
-    #     """ Sunang calculation timeseries """ 
+    def test_sunang_timeseries(self):
+        """ Sunang calculation timeseries """ 
 
-    #     # RME basin lat/lon
-    #     lon = -116.7547
-    #     lat = 43.067
+        # RME basin lat/lon
+        lon = -116.7547
+        lat = 43.067
 
-    #     date_time = pd.date_range('2015-10-01 00:00', '2016-09-30 00:00', freq='H', tz='UTC')
+        date_time = pd.date_range('2015-10-01 00:00', '2016-09-30 00:00', freq='H', tz='UTC')
         
-    #     df = pd.DataFrame(
-    #         index=date_time,
-    #         columns=['ipw_cosz', 'ipw_az', 'pysolar_cosz', 'pysolar_az']
-    #         )
+        df = pd.DataFrame(
+            index=date_time,
+            columns=['ipw_cosz', 'ipw_az', 'py_cosz', 'py_az']
+            )
 
-    #     for dt in date_time:
-    #         print(dt)
-    #         result = radiation.sunang(dt, lat, lon)
-    #         df.loc[dt, ['ipw_cosz', 'ipw_az']] = result
+        for dt in date_time:
+            print(dt)
+            result = radiation.sunang(dt, lat, lon)
+            df.loc[dt, ['ipw_cosz', 'ipw_az']] = result
 
-    #         result = radiation.pysolar_sunang(dt, lat, lon)
-    #         df.loc[dt, ['pysolar_cosz', 'pysolar_az']] = result
+            result = sunang.sunang(dt, lat, lon)
+            df.loc[dt, ['py_cosz', 'py_az']] = result
 
-    #     df['zen_diff'] = (df['ipw_cosz'] - df['pysolar_cosz']) * 180 / np.pi
-    #     df['az_diff'] = df['ipw_az'] - df['pysolar_az']
+        df['zen_diff'] = (df['ipw_cosz'] - df['py_cosz']) * 180 / np.pi
+        df['az_diff'] = df['ipw_az'] - df['py_az']
 
-    #     df.to_csv('sunang_comparison.csv')
+        df.to_csv('sunang_comparison.csv')
 
-    #     ax = df['zen_diff'].hist(bins=50)
-    #     ax.set_title('IPW zenith - Pysolar zenith')
-    #     ax.set_xlabel('Zenith difference, degrees')
+        ax = df['zen_diff'].hist(bins=50)
+        ax.set_title('IPW zenith - Python zenith')
+        ax.set_xlabel('Zenith difference, degrees')
         
-    #     ax = df['az_diff'].hist(bins=50)
-    #     ax.set_title('IPW azimuth - Pysolar azimuth')
-    #     ax.set_xlabel('Azimuth difference, degrees')
+        ax = df['az_diff'].hist(bins=50)
+        ax.set_title('IPW azimuth - Python azimuth')
+        ax.set_xlabel('Azimuth difference, degrees')
         


### PR DESCRIPTION
The sun angle calculation was done with a subprocess call to the IPW `sunang` function. The calculations were extracted from IPW and converted to Python. Tests were added to ensure that the sun angle functions were returning correct values and improved on the functionality. If latitude and longitude are provided as a numpy array, `sunang` will calculate the sun angle for every point.

## At a point, single date
The first test replicates the example in the IPW man page for `sunang` with no difference between the example and the Python version. The values must be truncated in Python to match the print to `stdout` that SMRF reads from. The truncation can be turned off if needed or is a numpy array is passed.

## At a point, whole water year
Comparing over a full water year for RME shows very little differences, most likely in the precision of the print statements. The azimuth below shows a difference in azimuth (degrees) of less that 0.01 degrees.
![smrf_sunang_azimuth](https://user-images.githubusercontent.com/7975741/66071787-043fb700-e511-11e9-87a6-0a78436020ac.png)

The RME zenith angle in degrees is similar, with absolute values less than 0.0002 degrees.
![smrf_sunang_zenith](https://user-images.githubusercontent.com/7975741/66071847-19b4e100-e511-11e9-91f1-331f4062beff.png)

This text (csv) file show the difference for every hour in this test. The code used to generate the figures and text file are in `tests/test_radiation.py`.
[sunang_comparison.txt](https://github.com/USDA-ARS-NWRC/smrf/files/3682791/sunang_comparison.txt)

## Affects to net solar radiation
With the small differences, the net solar radiation is not the same as the gold standard for RME causing the tests to fail. However, looking at the differences most values are about 0 with a maximum of 0.175 W/m2 which is insignificant for the magnitude of solar radiation. Accepting this PR will require an update in the gold standard.
![smrf_net_solar_diff](https://user-images.githubusercontent.com/7975741/66072005-731d1000-e511-11e9-898f-e67b1d0995b7.png)

## Sun angle for a whole basin
With the sun angle in Python, we can now pass latitude and longitude as an array. This will return an array of `cosz` and `azimuth` that can be provided to functions when they are ready. This will require rework of illumination angle and solar modules. Below is an example from the Tuolumne River Basin. `cosz` does not vary widely across the basin but the `azimuth` does have some differences of around 1 degree from one side to the other.
![smrf_sunang_cosz_tuolumne](https://user-images.githubusercontent.com/7975741/66072384-2980f500-e512-11e9-9b70-057d2fd0546a.png)
![smrf_sunang_azimuth_tuolumne](https://user-images.githubusercontent.com/7975741/66072388-2b4ab880-e512-11e9-9e17-2dc55faf4cb8.png)

