### PR TITLE
 Updating inicheck to 0.7.0+ in release 0.9

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ docutils==0.14
 flake8==3.5.0
 humanfriendly==4.6
 imagesize==0.7.1
-inicheck>=0.3.3,<0.4.0
+inicheck>=0.7.0.,<0.8.0
 Jinja2>=2.10.1
 latexcodec==1.0.5
 MarkupSafe==1.0

--- a/smrf/distribute/wind.py
+++ b/smrf/distribute/wind.py
@@ -132,7 +132,7 @@ class wind(image_data.image_data):
             self.wind_ninja_dxy = self.config['wind_ninja_dxy']
             self.wind_ninja_pref = self.config['wind_ninja_pref']
             if self.config['wind_ninja_tz'] is not None:
-                self.wind_ninja_tz = pytz.timezone(self.config['wind_ninja_tz'])
+                self.wind_ninja_tz = pytz.timezone(self.config['wind_ninja_tz'].title())
 
             self.start_date = pd.to_datetime(wholeConfig['time']['start_date'])
             self.grid_data = wholeConfig['gridded']['data_type']

--- a/smrf/framework/CoreConfig.ini
+++ b/smrf/framework/CoreConfig.ini
@@ -502,7 +502,7 @@ reduction_factor: default = 0.7,
 								 	type = float,
 								 	description = If wind speeds are still off here is a scaling factor
 
-maxus_netcdf:			type = CriticalFilename,
+maxus_netcdf:			type = DiscretionaryCriticalFilename,
 									description = NetCDF file containing the maxus values for wind
 
 grid_local:	default = False,

--- a/smrf/framework/CoreConfig.ini
+++ b/smrf/framework/CoreConfig.ini
@@ -648,7 +648,7 @@ regression_method:									default = 1,
                                     description = Polyfit order to use when using detrended kriging
 
 storm_days_restart:									default = None,
-																		type =  CriticalFilename,
+																		type =  DiscretionaryCriticalFilename,
 																		description = Path to netcdf representing the last storm days so a run can continue in between stops
 
 adjust_for_undercatch:							default = true,
@@ -1081,12 +1081,13 @@ frequency:			default = 1,
 								description = Number of timesteps to output data.
 
 out_location:		default = None,
-								type = CriticalDirectory,
+								type = Directory,
 								description = Directory to output results
 
 variables:      default = [thermal air_temp vapor_pressure wind_speed
                           wind_direction net_solar precip percent_snow
                           snow_density precip_temp],
+		type= string list,
       					options = [all air_temp albedo_vis albedo_ir precip percent_snow
       					 					snow_density storm_days precip_temp
       										clear_ir_beam clear_ir_diffuse clear_vis_beam

--- a/smrf/framework/model_framework.py
+++ b/smrf/framework/model_framework.py
@@ -40,7 +40,6 @@ import shutil
 from inicheck.tools import get_user_config, check_config
 from inicheck.config import UserConfig
 from inicheck.output import print_config_report,generate_config, print_recipe_summary
-from inicheck.utilities import pcfg, get_relative_to_cfg
 
 
 class SMRF():
@@ -164,7 +163,7 @@ class SMRF():
         for line in title:
             self._logger.info(line)
 
-        out = get_relative_to_cfg(ucfg.cfg['output']['out_location'],ucfg.filename)
+        out = ucfg.cfg['output']['out_location']
 
         #Make the tmp and output directories if they do not exist
         makeable_dirs = [out,os.path.join(out,'tmp')]
@@ -195,16 +194,13 @@ class SMRF():
         # Write the config file to the output dir no matter where the project is
         fname = 'config.ini'
         full_config_out = self.config['output']['out_location']
+
         full_config_out = os.path.abspath(os.path.join(
                                           os.path.dirname(configFile),
                                           full_config_out,fname))
 
         self._logger.info("Writing config file with full options.")
         generate_config(self.ucfg,full_config_out)
-
-        # After writing update the paths to be full abs paths.
-        self.config = self.ucfg.update_config_paths()
-
 
         # process the system variables
         for k,v in self.config['system'].items():

--- a/smrf/utils/utils.py
+++ b/smrf/utils/utils.py
@@ -29,11 +29,20 @@ class CheckStation(CheckType):
     def __init__(self,**kwargs):
         super(CheckStation,self).__init__(**kwargs)
 
-    def cast(self):
-        if self.value.lower() != 'none':
-            return self.value.upper()
-        else:
-            return self.value
+
+    def type_func(self, value):
+        """
+        Attempt to convert all the values to upper case.
+
+        Args:
+            value: A single string in a a config entry representing a station name
+        Returns:
+            value: A single station name all upper case
+        """
+
+        value = value.upper()
+
+        return value
 
 
 def find_configs(directory):


### PR DESCRIPTION
inicheck was not correctly handling certain items in the config file in 0.3.0 - 0.4.0. There was a few updates that now have fixed those things. @robertson-mark  and I concluded it was best to have this in the release since it was misleading and would likely cause aggravation down the line. 

Changes:

1. Requirements upgraded inicheck 
2. Critical paths no longer accept None, instead use discrectionary for paths that need to exist when they are not none.
3. Checkers now handle all the values in an entry, this means that list checking, option checking are handled more accurately. So CheckStation needed to be updated.
4. Getting paths relative the config is being handled inside inicheck now and the functions being used before were misleading.


Note that this work has already been done in master.