### PR TITLE
Improve logger

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-coloredlogs==6.1
+coloredlogs
 Cython>=0.28.4
 inicheck>=0.9.0,<0.10.0
 mysql-connector-python-rf==2.2.2

--- a/smrf/distribute/air_temp.py
+++ b/smrf/distribute/air_temp.py
@@ -40,7 +40,6 @@ class ta(image_data.image_data):
     # be written during main distribute loop
     post_process_variables = {}
 
-    # @add_logger()
     def __init__(self, taConfig):
 
         # extend the base class

--- a/smrf/distribute/air_temp.py
+++ b/smrf/distribute/air_temp.py
@@ -4,8 +4,10 @@ import logging
 
 from smrf.distribute import image_data
 from smrf.utils import utils
+from smrf.framework.logger import add_logger
 
 
+@add_logger()
 class ta(image_data.image_data):
     """
     The :mod:`~smrf.distribute.air_temp.ta` class allows for variable specific
@@ -52,7 +54,7 @@ class ta(image_data.image_data):
 
         # check and assign the configuration
         self.getConfig(taConfig)
-
+        self._logger.debug('Test debug')
         self._logger.debug('Created distribute.air_temp')
 
     def initialize(self, topo, data):

--- a/smrf/distribute/air_temp.py
+++ b/smrf/distribute/air_temp.py
@@ -1,13 +1,7 @@
-
-# import numpy as np
-import logging
-
 from smrf.distribute import image_data
 from smrf.utils import utils
-from smrf.framework.logger import add_logger
 
 
-@add_logger()
 class ta(image_data.image_data):
     """
     The :mod:`~smrf.distribute.air_temp.ta` class allows for variable specific
@@ -46,15 +40,14 @@ class ta(image_data.image_data):
     # be written during main distribute loop
     post_process_variables = {}
 
+    # @add_logger()
     def __init__(self, taConfig):
 
         # extend the base class
         image_data.image_data.__init__(self, self.variable)
-        self._logger = logging.getLogger(__name__)
 
         # check and assign the configuration
         self.getConfig(taConfig)
-        self._logger.debug('Test debug')
         self._logger.debug('Created distribute.air_temp')
 
     def initialize(self, topo, data):

--- a/smrf/distribute/albedo.py
+++ b/smrf/distribute/albedo.py
@@ -1,5 +1,3 @@
-import logging
-
 import numpy as np
 
 from smrf.distribute import image_data

--- a/smrf/distribute/albedo.py
+++ b/smrf/distribute/albedo.py
@@ -61,7 +61,6 @@ class Albedo(image_data.image_data):
 
         # extend the base class
         image_data.image_data.__init__(self, self.variable)
-        self._logger = logging.getLogger(__name__)
 
         # Get the veg values for the decay methods. Date method uses self.veg
         # Hardy2000 uses self.litter

--- a/smrf/distribute/cloud_factor.py
+++ b/smrf/distribute/cloud_factor.py
@@ -45,7 +45,6 @@ class cf(image_data.image_data):
 
         # extend the base class
         image_data.image_data.__init__(self, self.variable)
-        self._logger = logging.getLogger(__name__)
 
         # check and assign the configuration
         self.getConfig(config)

--- a/smrf/distribute/cloud_factor.py
+++ b/smrf/distribute/cloud_factor.py
@@ -1,5 +1,3 @@
-import logging
-
 from smrf.distribute import image_data
 from smrf.utils import utils
 

--- a/smrf/distribute/image_data.py
+++ b/smrf/distribute/image_data.py
@@ -50,7 +50,7 @@ class image_data():
 
         self.gridded = False
 
-        self._base_logger = logging.getLogger(__name__)
+        self._logger = logging.getLogger(self.__class__.__module__)
 
     def getConfig(self, cfg):
         """

--- a/smrf/distribute/precipitation.py
+++ b/smrf/distribute/precipitation.py
@@ -106,7 +106,6 @@ class ppt(image_data.image_data):
 
         # extend the base class
         image_data.image_data.__init__(self, self.variable)
-        self._logger = logging.getLogger(__name__)
 
         # check and assign the configuration
         self.getConfig(pptConfig)

--- a/smrf/distribute/precipitation.py
+++ b/smrf/distribute/precipitation.py
@@ -1,6 +1,4 @@
 
-import logging
-
 import netCDF4 as nc
 import numpy as np
 

--- a/smrf/distribute/soil_temp.py
+++ b/smrf/distribute/soil_temp.py
@@ -44,7 +44,6 @@ class ts(image_data.image_data):
 
         # extend the base class
         image_data.image_data.__init__(self, self.variable)
-        self._logger = logging.getLogger(__name__)
 
         self.config = soilConfig
 

--- a/smrf/distribute/soil_temp.py
+++ b/smrf/distribute/soil_temp.py
@@ -1,6 +1,3 @@
-
-import logging
-
 import numpy as np
 
 from smrf.distribute import image_data

--- a/smrf/distribute/solar.py
+++ b/smrf/distribute/solar.py
@@ -1,5 +1,3 @@
-import logging
-
 from smrf.distribute import image_data
 from smrf.envphys.constants import IR_WAVELENGTHS, VISIBLE_WAVELENGTHS
 from smrf.envphys.solar import cloud, toporad, vegetation

--- a/smrf/distribute/solar.py
+++ b/smrf/distribute/solar.py
@@ -211,7 +211,6 @@ class Solar(image_data.image_data):
 
         # extend the base class
         image_data.image_data.__init__(self, self.variable)
-        self._logger = logging.getLogger(__name__)
 
         self.config = config["solar"]
         self.albedoConfig = config["albedo"]

--- a/smrf/distribute/thermal.py
+++ b/smrf/distribute/thermal.py
@@ -194,7 +194,6 @@ class th(image_data.image_data):
 
         # extend the base class
         image_data.image_data.__init__(self, self.variable)
-        self._logger = logging.getLogger(__name__)
         self.getConfig(thermalConfig)
 
         self.min = thermalConfig['min']

--- a/smrf/distribute/thermal.py
+++ b/smrf/distribute/thermal.py
@@ -1,5 +1,3 @@
-import logging
-
 import numpy as np
 
 from smrf.distribute import image_data

--- a/smrf/distribute/vapor_pressure.py
+++ b/smrf/distribute/vapor_pressure.py
@@ -1,6 +1,4 @@
 
-import logging
-
 import numpy as np
 
 from smrf.distribute import image_data

--- a/smrf/distribute/vapor_pressure.py
+++ b/smrf/distribute/vapor_pressure.py
@@ -67,7 +67,6 @@ class vp(image_data.image_data):
 
         # extend the base class
         image_data.image_data.__init__(self, self.variable)
-        self._logger = logging.getLogger(__name__)
 
         # check and assign the configuration
         self.getConfig(vpConfig)

--- a/smrf/framework/logger.py
+++ b/smrf/framework/logger.py
@@ -64,14 +64,24 @@ class SMRFLogger():
                     'class': 'logging.StreamHandler',
                     'stream': 'ext://sys.stdout',  # Default is stderr
                 },
+                'log_file': {
+                    'level': self.log_level,
+                    'formatter': 'standard',
+                    'class': 'logging.FileHandler',
+                    'filename': self.log_file,
+                    'mode': 'a'
+                }
             },
             'loggers': {
                 '': {  # root logger
-                    'handlers': ['default'],
+                    'handlers': ['log_file'],
                     'level': self.log_level,
                     'propagate': False
                 }
             }
         }
+
+        # if self.log_file is not None:
+        #     log_config['handlers']['log_file']['filename'] = self.log_file
 
         logging.config.dictConfig(log_config)

--- a/smrf/framework/logger.py
+++ b/smrf/framework/logger.py
@@ -1,0 +1,77 @@
+import logging.config
+import os
+
+import coloredlogs
+
+
+def add_logger():
+    def wrapper(cls):
+
+        cls._logger = logging.getLogger(cls.__name__)
+
+        return cls
+    return wrapper
+
+
+class SMRFLogger():
+    """Setup the root logger for SMRF
+
+    Raises:
+        ValueError: [description]
+    """
+
+    FMT = '%(levelname)s:%(name)s:%(message)s'
+
+    def __init__(self, config):
+
+        self.log_level = config.get('log_level', 'info').upper()
+
+        numeric_level = getattr(logging, self.log_level, None)
+        if not isinstance(numeric_level, int):
+            raise ValueError('Invalid log level: {}'.format(self.log_level))
+
+        # setup the logging
+        self.log_file = config.get('log_file', None)
+        if self.log_file is not None:
+            os.makedirs(os.path.dirname(self.log_file), exist_ok=True)
+
+            # From the python3 docs on basicConfig
+            # "This function does nothing if the root logger already has
+            # handlers configured"
+            # for handler in logging.root.handlers[:]:
+            #     logging.root.removeHandler(handler)
+
+            # logging.basicConfig(filename=self.log_file,
+            #                     level=numeric_level,
+            #                     filemode='a',
+            #                     format=self.FMT)
+        # else:
+            # logging.basicConfig(level=numeric_level)
+            # coloredlogs.install(level=numeric_level, fmt=self.FMT)
+
+        # https://docs.python.org/3/library/logging.config.html#configuration-dictionary-schema
+        log_config = {
+            'version': 1,
+            'formatters': {
+                'standard': {
+                    'format': self.FMT
+                }
+            },
+            'handlers': {
+                'default': {
+                    'level': self.log_level,
+                    'formatter': 'standard',
+                    'class': 'logging.StreamHandler',
+                    'stream': 'ext://sys.stdout',  # Default is stderr
+                },
+            },
+            'loggers': {
+                '': {  # root logger
+                    'handlers': ['default'],
+                    'level': self.log_level,
+                    'propagate': False
+                }
+            }
+        }
+
+        logging.config.dictConfig(log_config)

--- a/smrf/framework/logger.py
+++ b/smrf/framework/logger.py
@@ -4,20 +4,9 @@ import os
 import coloredlogs
 
 
-def add_logger():
-    def wrapper(cls):
-
-        cls._logger = logging.getLogger(cls.__name__)
-
-        return cls
-    return wrapper
-
-
 class SMRFLogger():
-    """Setup the root logger for SMRF
-
-    Raises:
-        ValueError: [description]
+    """Setup the root logger for SMRF to either the console or
+    to a file
     """
 
     FMT = '%(levelname)s:%(name)s:%(message)s'
@@ -25,29 +14,7 @@ class SMRFLogger():
     def __init__(self, config):
 
         self.log_level = config.get('log_level', 'info').upper()
-
-        numeric_level = getattr(logging, self.log_level, None)
-        if not isinstance(numeric_level, int):
-            raise ValueError('Invalid log level: {}'.format(self.log_level))
-
-        # setup the logging
         self.log_file = config.get('log_file', None)
-        if self.log_file is not None:
-            os.makedirs(os.path.dirname(self.log_file), exist_ok=True)
-
-            # From the python3 docs on basicConfig
-            # "This function does nothing if the root logger already has
-            # handlers configured"
-            # for handler in logging.root.handlers[:]:
-            #     logging.root.removeHandler(handler)
-
-            # logging.basicConfig(filename=self.log_file,
-            #                     level=numeric_level,
-            #                     filemode='a',
-            #                     format=self.FMT)
-        # else:
-            # logging.basicConfig(level=numeric_level)
-            # coloredlogs.install(level=numeric_level, fmt=self.FMT)
 
         # https://docs.python.org/3/library/logging.config.html#configuration-dictionary-schema
         log_config = {
@@ -63,25 +30,31 @@ class SMRFLogger():
                     'formatter': 'standard',
                     'class': 'logging.StreamHandler',
                     'stream': 'ext://sys.stdout',  # Default is stderr
-                },
-                'log_file': {
-                    'level': self.log_level,
-                    'formatter': 'standard',
-                    'class': 'logging.FileHandler',
-                    'filename': self.log_file,
-                    'mode': 'a'
                 }
             },
             'loggers': {
                 '': {  # root logger
-                    'handlers': ['log_file'],
+                    'handlers': ['default'],
                     'level': self.log_level,
                     'propagate': False
                 }
             }
         }
 
-        # if self.log_file is not None:
-        #     log_config['handlers']['log_file']['filename'] = self.log_file
+        if self.log_file is not None:
+            os.makedirs(os.path.dirname(self.log_file), exist_ok=True)
+
+            log_config['handlers']['log_file'] = {
+                'level': self.log_level,
+                'formatter': 'standard',
+                'class': 'logging.FileHandler',
+                'filename': self.log_file,
+                'mode': 'a'
+            }
+
+            log_config['loggers']['']['handlers'] = ['log_file']
 
         logging.config.dictConfig(log_config)
+
+        if self.log_file is None:
+            coloredlogs.install(level=self.log_level, fmt=self.FMT)

--- a/smrf/framework/model_framework.py
+++ b/smrf/framework/model_framework.py
@@ -41,7 +41,7 @@ from topocalc.shade import shade
 
 from smrf import data, distribute
 from smrf.output import output_netcdf, output_hru
-from smrf.framework import art
+from smrf.framework import art, logger
 from smrf.envphys import sunang
 from smrf.envphys.solar import model
 from smrf.utils import queue
@@ -118,39 +118,40 @@ class SMRF():
                             ' UserConfig instance')
         # start logging
         if external_logger is None:
+            self.smrf_logger = logger.SMRFLogger(ucfg.cfg['system'])
 
-            if 'log_level' in ucfg.cfg['system']:
-                loglevel = ucfg.cfg['system']['log_level'].upper()
-            else:
-                loglevel = 'INFO'
+            # if 'log_level' in ucfg.cfg['system']:
+            #     loglevel = ucfg.cfg['system']['log_level'].upper()
+            # else:
+            #     loglevel = 'INFO'
 
-            numeric_level = getattr(logging, loglevel, None)
-            if not isinstance(numeric_level, int):
-                raise ValueError('Invalid log level: %s' % loglevel)
+            # numeric_level = getattr(logging, loglevel, None)
+            # if not isinstance(numeric_level, int):
+            #     raise ValueError('Invalid log level: %s' % loglevel)
 
-            # setup the logging
-            logfile = None
-            if ucfg.cfg['system']['log_file'] is not None:
-                logfile = ucfg.cfg['system']['log_file']
-                os.makedirs(dirname(logfile), exist_ok=True)
+            # # setup the logging
+            # logfile = None
+            # if ucfg.cfg['system']['log_file'] is not None:
+            #     logfile = ucfg.cfg['system']['log_file']
+            #     os.makedirs(dirname(logfile), exist_ok=True)
 
-            fmt = '%(levelname)s:%(name)s:%(message)s'
-            if logfile is not None:
-                # From the python3 docs on basicConfig
-                # "This function does nothing if the root logger already has
-                # handlers configured"
-                for handler in logging.root.handlers[:]:
-                    logging.root.removeHandler(handler)
+            # fmt = '%(levelname)s:%(name)s:%(message)s'
+            # if logfile is not None:
+            #     # From the python3 docs on basicConfig
+            #     # "This function does nothing if the root logger already has
+            #     # handlers configured"
+            #     for handler in logging.root.handlers[:]:
+            #         logging.root.removeHandler(handler)
 
-                logging.basicConfig(filename=logfile,
-                                    level=numeric_level,
-                                    filemode='a',
-                                    format=fmt)
-            else:
-                logging.basicConfig(level=numeric_level)
-                coloredlogs.install(level=numeric_level, fmt=fmt)
+            #     logging.basicConfig(filename=logfile,
+            #                         level=numeric_level,
+            #                         filemode='a',
+            #                         format=fmt)
+            # else:
+            #     logging.basicConfig(level=numeric_level)
+            #     coloredlogs.install(level=numeric_level, fmt=fmt)
 
-            self._loglevel = numeric_level
+            # self._loglevel = numeric_level
 
             self._logger = logging.getLogger(__name__)
         else:

--- a/smrf/framework/model_framework.py
+++ b/smrf/framework/model_framework.py
@@ -27,10 +27,9 @@ import logging
 import os
 import sys
 from datetime import datetime
-from os.path import abspath, dirname, join
+from os.path import abspath, join
 from threading import Thread
 
-import coloredlogs
 import numpy as np
 import pandas as pd
 import pytz
@@ -40,10 +39,10 @@ from inicheck.tools import check_config, get_user_config
 from topocalc.shade import shade
 
 from smrf import data, distribute
-from smrf.output import output_netcdf, output_hru
-from smrf.framework import art, logger
 from smrf.envphys import sunang
 from smrf.envphys.solar import model
+from smrf.framework import art, logger
+from smrf.output import output_hru, output_netcdf
 from smrf.utils import queue
 from smrf.utils.utils import backup_input, check_station_colocation, getqotw
 
@@ -119,40 +118,6 @@ class SMRF():
         # start logging
         if external_logger is None:
             self.smrf_logger = logger.SMRFLogger(ucfg.cfg['system'])
-
-            # if 'log_level' in ucfg.cfg['system']:
-            #     loglevel = ucfg.cfg['system']['log_level'].upper()
-            # else:
-            #     loglevel = 'INFO'
-
-            # numeric_level = getattr(logging, loglevel, None)
-            # if not isinstance(numeric_level, int):
-            #     raise ValueError('Invalid log level: %s' % loglevel)
-
-            # # setup the logging
-            # logfile = None
-            # if ucfg.cfg['system']['log_file'] is not None:
-            #     logfile = ucfg.cfg['system']['log_file']
-            #     os.makedirs(dirname(logfile), exist_ok=True)
-
-            # fmt = '%(levelname)s:%(name)s:%(message)s'
-            # if logfile is not None:
-            #     # From the python3 docs on basicConfig
-            #     # "This function does nothing if the root logger already has
-            #     # handlers configured"
-            #     for handler in logging.root.handlers[:]:
-            #         logging.root.removeHandler(handler)
-
-            #     logging.basicConfig(filename=logfile,
-            #                         level=numeric_level,
-            #                         filemode='a',
-            #                         format=fmt)
-            # else:
-            #     logging.basicConfig(level=numeric_level)
-            #     coloredlogs.install(level=numeric_level, fmt=fmt)
-
-            # self._loglevel = numeric_level
-
             self._logger = logging.getLogger(__name__)
         else:
             self._logger = external_logger

--- a/smrf/tests/smrf_test_case.py
+++ b/smrf/tests/smrf_test_case.py
@@ -1,7 +1,7 @@
+import logging
 import os
 import shutil
 import unittest
-import logging
 
 import netCDF4 as nc
 import numpy as np

--- a/smrf/tests/smrf_test_case_lakes.py
+++ b/smrf/tests/smrf_test_case_lakes.py
@@ -1,6 +1,6 @@
+import logging
 import os
 import shutil
-import logging
 
 from inicheck.tools import get_user_config
 

--- a/smrf/tests/test_base_config.ini
+++ b/smrf/tests/test_base_config.ini
@@ -113,5 +113,5 @@ out_location:                  ./RME/output
 ################################################################################
 
 [system]
-log_file:                      ./RME/output/log.txt
+#log_file:                      ./RME/output/log.txt
 time_out:                      25

--- a/smrf/tests/test_base_config.ini
+++ b/smrf/tests/test_base_config.ini
@@ -113,5 +113,5 @@ out_location:                  ./RME/output
 ################################################################################
 
 [system]
-#log_file:                      ./RME/output/log.txt
+log_file:                      ./RME/output/log.txt
 time_out:                      25


### PR DESCRIPTION
The `logging.basicConfig` makes a lot of assumptions that were creating some issues in the test environment. Now uses the `dictConfig` to create the logger directly with much more control. Works with both streaming and file handlers.