### PR TITLE
186 awsm integration

### DIFF
--- a/smrf/framework/model_framework.py
+++ b/smrf/framework/model_framework.py
@@ -642,7 +642,7 @@ class SMRF():
 
             if output_variable in self.possible_output_variables.keys():
                 fname = join(out_location, output_variable)
-                module = self.possible_output_variables[output_variable]['module']
+                module = self.possible_output_variables[output_variable]['module']  # noqa
 
                 # TODO this is a hack to not have to redo the gold files
                 if module == 'precipitation':


### PR DESCRIPTION
There was a lot of duplicate code in AWSM from SMRF. This cleans up some of the variables or functions that need to be accessed from AWSM.

- `distribute_single_timestep()` method will distribute a single time step
- renamed some methods to be clearer about running in serial or threaded
- output variable dictionary that returns a dictionary
- can pass an external logger to `run_smrf`