### PR TITLE
189 output 64-bit netcdf files

### DIFF
--- a/smrf/framework/CoreConfig.ini
+++ b/smrf/framework/CoreConfig.ini
@@ -1169,6 +1169,11 @@ default = netcdf,
 options = [netcdf],
 description = Format to use for outputting data.
 
+netcdf_output_precision:
+default = float,
+options = [float double],
+description = NetCDF variable output precision for float (32-bit) or double (64-bit) 
+
 input_backup:  default = true,
 type = bool,
 description = Specify whether to backup the input data and create config file

--- a/smrf/output/output_netcdf.py
+++ b/smrf/output/output_netcdf.py
@@ -55,6 +55,8 @@ class OutputNetcdf():
         # Retrieve projection information from topo
         map_meta = add_proj_from_file(topo.topoConfig['filename'])
 
+        precision = self.outConfig['netcdf_output_precision'][0]
+
         for v in self.variable_dict:
 
             f = self.variable_dict[v]
@@ -85,7 +87,8 @@ class OutputNetcdf():
                 s.createVariable('time', 'f', (dimensions[0]))
                 s.createVariable('y', 'f', dimensions[1])
                 s.createVariable('x', 'f', dimensions[2])
-                s.createVariable(f['variable'], 'f',
+                s.createVariable(f['variable'],
+                                 precision,
                                  (dimensions[0], dimensions[1], dimensions[2]),
                                  chunksizes=self.cs)
 


### PR DESCRIPTION
Added an option to output SMRF netcdf files as float (32-bit) or double (64-bit). The default is float (32-bit) and the option for double will be used in AWSM when comparing all the different methods.