### PR TITLE
197 image data

### DIFF
--- a/smrf/distribute/image_data.py
+++ b/smrf/distribute/image_data.py
@@ -1,4 +1,5 @@
 import logging
+from copy import deepcopy
 
 import numpy as np
 
@@ -223,8 +224,10 @@ class image_data():
         """
 
         # get the data for the desired stations
-        # this will also order it correctly how air_temp was initialized
-        data = data[self.stations]
+        # this will also order it correctly how image_data was initialized and
+        # fill any stations not in data as NaN
+        data = deepcopy(data)
+        data = data.reindex(self.stations)
 
         if np.sum(data.isnull()) == data.shape[0]:
             raise Exception("{}: All data values are NaN"

--- a/smrf/distribute/precipitation.py
+++ b/smrf/distribute/precipitation.py
@@ -267,7 +267,7 @@ class ppt(image_data.image_data):
         """
 
         self._logger.debug('%s Distributing all precip' % data.name)
-        data = data[self.stations]
+        data = data.reindex(self.stations)
 
         if self.config['distribution'] != 'grid':
             if self.nasde_model == 'marks2017':

--- a/smrf/tests/basins/Lakes/config_issue_197.ini
+++ b/smrf/tests/basins/Lakes/config_issue_197.ini
@@ -90,6 +90,7 @@ wind_ninja_tz:                  UTC
 [precip]
 distribution:                   grid
 grid_method:                    cubic
+#grid_local:                     True
 detrend:                        True
 detrend_slope:                  1
 grid_mask:                      False
@@ -183,3 +184,4 @@ threading:                     False
 queue_max_values:              1
 time_out:                      None
 log_level:                     debug
+log_file:                      ./output/log.txt

--- a/smrf/tests/basins/Lakes/config_issue_197.ini
+++ b/smrf/tests/basins/Lakes/config_issue_197.ini
@@ -1,0 +1,185 @@
+################################################################################
+
+# For details on configuration file syntax see:
+# https://docs.python.org/2/library/configparser.html
+#
+# For more SMRF related help see:
+# http://smrf.readthedocs.io/en/latest/
+
+
+################################################################################
+# Files for DEM and vegetation
+################################################################################
+
+[topo]
+filename:                      ./topo/topo.nc
+gradient_method:               gradient_d8
+sky_view_factor_angles:        72
+
+
+################################################################################
+# Dates to run model
+################################################################################
+
+[time]
+time_step:                     60
+start_date: 			       2018-12-04 12:00:00
+end_date: 			           2018-12-04 14:00:00
+time_zone:                     UTC
+
+
+################################################################################
+# Gridded dataset i.e. wrf_out
+################################################################################
+
+[gridded]
+data_type:                     hrrr_grib
+hrrr_directory:                /data/snowpack/forecasts/hrrr_crop/lakes
+hrrr_load_method:              timestep
+
+
+################################################################################
+# Air temperature distribution
+################################################################################
+
+[air_temp]
+distribution:                  grid
+grid_method:                   cubic
+detrend:                       True
+detrend_slope:                 -1
+grid_mask:                     False
+grid_local:		               True
+min:                           -73.0
+max:                           47.0
+
+################################################################################
+# Vapor pressure distribution
+################################################################################
+
+[vapor_pressure]
+distribution:                  grid
+grid_method:                   cubic
+detrend:                       True
+detrend_slope:                 -1
+grid_mask:                     False
+grid_local:		               True
+dew_point_tolerance:           0.01
+dew_point_nthreads:            8
+min:                           20.0
+max:                           5000.0
+
+################################################################################
+# Wind speed and wind direction distribution
+################################################################################
+
+[wind]
+wind_model:                     wind_ninja
+distribution:                   grid
+min:                            0.5
+max:                            30.0
+grid_mask:                      False
+wind_ninja_dir:                 /data/albedo/lakes/wy2019/lakes_test_susong1999/wind_ninja
+wind_ninja_dxdy:                50
+wind_ninja_pref:                topo_windninja_topo
+wind_ninja_tz:                  UTC
+
+################################################################################
+# Precipitation distribution
+################################################################################
+
+[precip]
+distribution:                   grid
+grid_method:                    cubic
+detrend:                        True
+detrend_slope:                  1
+grid_mask:                      False
+station_adjust_for_undercatch:  False
+storm_mass_threshold:           1.0
+storm_days_restart:             None
+min:                            0.0
+max:                            None
+new_snow_density_model:         susong1999
+susong1999_timesteps_to_end_storms:       6
+precip_temp_method:             wet_bulb
+
+
+################################################################################
+# Albedo distribution
+################################################################################
+
+[albedo]
+grain_size:                     100.0
+max_grain:                      700.0
+dirt:                           2.0
+max:                            1.0
+min:                            0.0
+grid_mask:                      True
+# albedo decay parameters
+decay_method:                   date_method
+date_method_start_decay:		2019-03-15
+date_method_end_decay:		    2019-7-1
+date_method_veg_default:        0.2
+date_method_decay_power:        0.714
+
+
+################################################################################
+# Cloud Factor - Fraction used to limit solar radiation Cloudy (0) - Sunny (1)
+################################################################################
+[cloud_factor]
+distribution:                   grid
+grid_method:                    cubic
+detrend:                        False
+grid_mask:                      False
+
+
+################################################################################
+# Solar radiation distribution
+################################################################################
+
+[solar]
+clear_opt_depth:                100.0
+clear_tau:                      0.2
+clear_omega:                    0.85
+clear_gamma:                    0.3
+min:                            0.0
+max:                            800.0
+
+
+################################################################################
+# Thermal radiation distribution
+################################################################################
+
+[thermal]
+cloud_method:                  garen2005
+marks1979_nthreads:            8
+min:                           0.0
+max:                           600.0
+grid_mask:                     True
+clear_sky_method:              marks1979
+
+################################################################################
+#  Soil temperature
+################################################################################
+
+[soil_temp]
+temp:                          -2.5
+
+################################################################################
+# Output variables
+################################################################################
+
+[output]
+frequency:                     1
+variables:                     thermal, air_temp, vapor_pressure, wind_speed, net_solar, precip, percent_snow, snow_density, precip_temp, storm_days, cloud_factor
+file_type:                     netcdf
+out_location:                  ./output
+
+################################################################################
+# System variables
+################################################################################
+
+[system]
+threading:                     False
+queue_max_values:              1
+time_out:                      None
+log_level:                     debug

--- a/smrf/tests/data/test_hrrr.py
+++ b/smrf/tests/data/test_hrrr.py
@@ -1,9 +1,12 @@
 from copy import deepcopy
-
+import os
+import pandas as pd
 from inicheck.tools import cast_all_variables
 
 from smrf.framework.model_framework import run_smrf
 from smrf.tests.smrf_test_case import SMRFTestCase
+from smrf.tests.smrf_test_case_lakes import SMRFTestCaseLakes
+from smrf.data.hrrr_grib import InputGribHRRR
 
 
 class TestLoadHRRR(SMRFTestCase):
@@ -95,3 +98,36 @@ class TestLoadHRRR(SMRFTestCase):
         run_smrf(config)
 
         self.compare_hrrr_gold()
+
+
+class TestLoadHRRRLakes(SMRFTestCaseLakes):
+
+    # @classmethod
+    # def setUpClass(cls):
+    #     super().setUpClass()
+
+    #     config = cls.base_config_copy()
+
+    #     adj_config = {
+    #         'time': {
+    #             'start_date': '2018-12-04 13:00',
+    #             'end_date': '2018-12-04 13:30',
+    #             'time_zone': 'utc'
+    #         },
+    #         'system': {
+    #             'threading': False,
+    #             'log_file': None
+    #         },
+    #     }
+    #     config.raw_cfg.update(adj_config)
+    #     config.apply_recipes()
+    #     config = cast_all_variables(config, config.mcfg)
+
+    #     cls.config = config
+
+    def test_197_image_data_index(self):
+
+        # run_smrf(self.config)
+        config_file = os.path.join(self.basin_dir, 'config_issue_197.ini')
+        run_smrf(config_file)
+        self.config

--- a/smrf/tests/data/test_hrrr.py
+++ b/smrf/tests/data/test_hrrr.py
@@ -1,12 +1,13 @@
 from copy import deepcopy
 import os
-import pandas as pd
+import unittest
+
 from inicheck.tools import cast_all_variables
 
 from smrf.framework.model_framework import run_smrf
 from smrf.tests.smrf_test_case import SMRFTestCase
 from smrf.tests.smrf_test_case_lakes import SMRFTestCaseLakes
-from smrf.data.hrrr_grib import InputGribHRRR
+from smrf.tests.nwrc_check import NWRCCheck
 
 
 class TestLoadHRRR(SMRFTestCase):
@@ -100,6 +101,10 @@ class TestLoadHRRR(SMRFTestCase):
         self.compare_hrrr_gold()
 
 
+@unittest.skipUnless(
+    NWRCCheck.in_network(),
+    "Skipping because we are not on the NWRC network"
+)
 class TestLoadHRRRLakes(SMRFTestCaseLakes):
 
     def test_197_image_data_index(self):

--- a/smrf/tests/data/test_hrrr.py
+++ b/smrf/tests/data/test_hrrr.py
@@ -102,32 +102,7 @@ class TestLoadHRRR(SMRFTestCase):
 
 class TestLoadHRRRLakes(SMRFTestCaseLakes):
 
-    # @classmethod
-    # def setUpClass(cls):
-    #     super().setUpClass()
-
-    #     config = cls.base_config_copy()
-
-    #     adj_config = {
-    #         'time': {
-    #             'start_date': '2018-12-04 13:00',
-    #             'end_date': '2018-12-04 13:30',
-    #             'time_zone': 'utc'
-    #         },
-    #         'system': {
-    #             'threading': False,
-    #             'log_file': None
-    #         },
-    #     }
-    #     config.raw_cfg.update(adj_config)
-    #     config.apply_recipes()
-    #     config = cast_all_variables(config, config.mcfg)
-
-    #     cls.config = config
-
     def test_197_image_data_index(self):
 
-        # run_smrf(self.config)
         config_file = os.path.join(self.basin_dir, 'config_issue_197.ini')
         run_smrf(config_file)
-        self.config

--- a/smrf/tests/nwrc_check.py
+++ b/smrf/tests/nwrc_check.py
@@ -1,0 +1,19 @@
+import requests
+
+
+class NWRCCheck(object):
+
+    HOST = '10.200.28.50/dashboard'
+    URL = 'http://' + HOST
+
+    @classmethod
+    def in_network(cls):
+        """
+        Checks that were on the NWRC network
+        """
+        try:
+            response = requests.get(cls.URL, timeout=1)
+            return response.ok
+
+        except requests.exceptions.RequestException:
+            return False


### PR DESCRIPTION
Working with cropped HRRR files, at one particular point the grib files were returning nan values for particular grid cells. This fix uses pandas `reindex()` to add NaN values to the data and deal with those values when performing the `grid_local` and `grid_mask` options.