### PR TITLE
Unknown veg_ values cause issues in albedo decay methods

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,7 @@ oset==0.1.3
 pandas==0.22.0
 pbr==3.1.1
 progressbar2==3.6.2
-pybtex==0.21
+pybtex==0.24
 pybtex-docutils==0.2.1
 pycodestyle==2.3.1
 pyflakes==1.5.0


### PR DESCRIPTION
* add test showing that albedo config parses unknown veg_ values as a list of strings rather than a float. 
* Update requirements for breaking build. use_2to3 is not allowed with latest setuptools
* Address issue #214 